### PR TITLE
GH-22 `events-ingress` map the new `Adobe I/O Events` Raw Events publication endpoint 

### DIFF
--- a/events_ingress/src/main/java/com/adobe/event/publish/PublishService.java
+++ b/events_ingress/src/main/java/com/adobe/event/publish/PublishService.java
@@ -24,6 +24,7 @@ public interface PublishService {
       throws JsonProcessingException;
   CloudEvent publishCloudEvent(String providerId, String eventCode, String eventId,  String data)
       throws JsonProcessingException;
+  void publishRawEvent(String providerId, String eventCode, String rawEvent);
 
   static Builder builder() {
     return new Builder();

--- a/events_ingress/src/main/java/com/adobe/event/publish/PublishServiceImpl.java
+++ b/events_ingress/src/main/java/com/adobe/event/publish/PublishServiceImpl.java
@@ -54,8 +54,12 @@ class PublishServiceImpl implements PublishService {
     CloudEvent inputModel = CloudEvent.builder()
         .providerId(providerId).eventCode(eventCode).eventId(eventId)
         .data(data).build();
-    publishApi.publish(inputModel);
+    publishApi.publishCloudEvent(inputModel);
     return inputModel;
   }
 
+  @Override
+  public void publishRawEvent(String providerId, String eventCode, String rawEvent) {
+    publishApi.publishRawEvent(providerId,  eventCode, rawEvent);
+  }
 }

--- a/events_ingress/src/main/java/com/adobe/event/publish/api/PublishApi.java
+++ b/events_ingress/src/main/java/com/adobe/event/publish/api/PublishApi.java
@@ -13,7 +13,9 @@ package com.adobe.event.publish.api;
 
 import com.adobe.event.publish.model.CloudEvent;
 import feign.Headers;
+import feign.Param;
 import feign.RequestLine;
+import java.util.Optional;
 
 @Headers("Accept: application/json")
 public interface PublishApi {
@@ -21,12 +23,29 @@ public interface PublishApi {
   String DEFAULT_URL = "https://eventsingress.adobe.io";
 
   /**
-   * publish a Cloud Event
+   * publish a Cloud Event Payload
    *
    * @param body your CloudEvent Input Model
    */
   @RequestLine("POST")
   @Headers({"Content-Type: application/cloudevents+json"})
-  void publish(CloudEvent body);
+  void publishCloudEvent(CloudEvent body);
+
+  /**
+   * publish a Raw Event Json Payload
+   * @param eventCode the Adobe I/O EventMetadata eventCode associated with the Event
+   * @param providerId  the Adobe I/O EventMetadata ProviderId associated with the Event
+   * @param rawEvent the Raw Event Json Payload to publish
+   */
+  @RequestLine("POST")
+  @Headers({
+      "Content-Type: application/json",
+      "x-adobe-event-provider-id: {providerId}",
+      "x-adobe-event-code: {eventCode}"
+  })
+  void publishRawEvent(
+      @Param("providerId") String providerId,
+      @Param("eventCode") String eventCode,
+      String rawEvent);
 
 }

--- a/events_ingress/src/test/java/com/adobe/event/publish/PublishServiceTestDrive.java
+++ b/events_ingress/src/test/java/com/adobe/event/publish/PublishServiceTestDrive.java
@@ -62,6 +62,9 @@ public class PublishServiceTestDrive {
           .workspace(workspace)
           .build();
 
+      String eventDataPayload =  "your event payload";
+      //String eventDataPayload = "   { \"key\" : \"value\" } ";
+
       PublishService publishService = PublishService.builder()
           .authInterceptor(authInterceptor) // [1]
           .url(prop.getProperty(AIO_PUBLISH_URL)) // you can omit this if you target prod
@@ -69,9 +72,14 @@ public class PublishServiceTestDrive {
       CloudEvent cloudEvent = publishService.publishCloudEvent(
           prop.getProperty(AIO_PROVIDER_ID),
           prop.getProperty(AIO_EVENT_CODE),
-          "your event payload");
-          //("   { \"key\" : \"value\" } "));
-      logger.info("published {}", JacksonUtil.DEFAULT_OBJECT_MAPPER.writeValueAsString(cloudEvent));
+          eventDataPayload);
+      logger.info("published Cloud Event{}", JacksonUtil.DEFAULT_OBJECT_MAPPER.writeValueAsString(cloudEvent));
+
+      // Adobe I/O Events Publishing API also allows the publication of simple/raw event json payload
+      publishService.publishRawEvent(prop.getProperty(AIO_PROVIDER_ID),
+          prop.getProperty(AIO_EVENT_CODE),
+          eventDataPayload);
+      logger.info("published Raw Event{}",eventDataPayload);
 
       System.exit(0);
     } catch (Exception e) {


### PR DESCRIPTION
https://github.com/adobe/aio-lib-java/issues/22

mapping the upcoming new publish API endpoint allow raw event payload  (non CloudEvents) to be published
