### PR TITLE
Issue 24 - Method to add multiple EventsOfInterest to the model

### DIFF
--- a/events_mgmt/src/main/java/com/adobe/event/management/model/RegistrationInputModel.java
+++ b/events_mgmt/src/main/java/com/adobe/event/management/model/RegistrationInputModel.java
@@ -157,6 +157,12 @@ public class RegistrationInputModel {
       return this;
     }
 
+    public Builder addMultipleEventsOfInterests(
+        Set<EventsOfInterest> multipleEventsOfInterest) {
+      this.eventsOfInterests.addAll(multipleEventsOfInterest);
+      return this;
+    }
+    
     public Builder webhookUrl(String webhookUrl) {
       this.webhookUrl = webhookUrl;
       return this;

--- a/events_mgmt/src/main/java/com/adobe/event/management/model/RegistrationInputModel.java
+++ b/events_mgmt/src/main/java/com/adobe/event/management/model/RegistrationInputModel.java
@@ -158,8 +158,8 @@ public class RegistrationInputModel {
     }
 
     public Builder addEventsOfInterests(
-        Set<EventsOfInterest> multipleEventsOfInterest) {
-      this.eventsOfInterests.addAll(multipleEventsOfInterest);
+        Set<EventsOfInterest> eventsOfInterest) {
+      this.eventsOfInterests.addAll(eventsOfInterest);
       return this;
     }
     

--- a/events_mgmt/src/main/java/com/adobe/event/management/model/RegistrationInputModel.java
+++ b/events_mgmt/src/main/java/com/adobe/event/management/model/RegistrationInputModel.java
@@ -157,7 +157,7 @@ public class RegistrationInputModel {
       return this;
     }
 
-    public Builder addMultipleEventsOfInterests(
+    public Builder addEventsOfInterests(
         Set<EventsOfInterest> multipleEventsOfInterest) {
       this.eventsOfInterests.addAll(multipleEventsOfInterest);
       return this;


### PR DESCRIPTION

## Description
Need this for someone who wants to register multiple combinations of Provider ID and Event Code to one Journal/Webhook.

## Related Issue

https://github.com/adobe/aio-lib-java/issues/24

## Motivation and Context

Need this for someone who wants to register multiple combinations of Provider ID and Event Code to one Journal/Webhook.

## How Has This Been Tested?

## Screenshots (if appropriate):

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [X] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [X] My code follows the [code style](CODE_STYLE.md) of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.




