### PR TITLE
Fix workflow

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -347,7 +347,7 @@
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-release-plugin</artifactId>
-          <version>2.5.3</version>
+          <version>3.0.0-M5</version>
           <configuration>
             <useReleaseProfile>false</useReleaseProfile>
             <releaseProfiles>release</releaseProfiles>
@@ -363,7 +363,7 @@
             <dependency>
               <groupId>org.apache.maven.release</groupId>
               <artifactId>maven-release-oddeven-policy</artifactId>
-              <version>2.5.3</version>
+              <version>3.0.0-M5</version>
             </dependency>
           </dependencies>
         </plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -354,13 +354,6 @@
             <autoVersionSubmodules>true</autoVersionSubmodules>
             <projectVersionPolicyId>OddEvenVersionPolicy</projectVersionPolicyId>
           </configuration>
-          <dependencies>
-            <dependency>
-              <groupId>org.apache.maven.release</groupId>
-              <artifactId>maven-release-oddeven-policy</artifactId>
-              <version>3.0.0-M5</version>
-            </dependency>
-          </dependencies>
         </plugin>
 
         <plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -356,11 +356,6 @@
           </configuration>
           <dependencies>
             <dependency>
-              <groupId>org.apache.maven.shared</groupId>
-              <artifactId>maven-invoker</artifactId>
-              <version>3.1.0</version> <!-- Freeze until 3.0.0 of Maven Release Plugin is GA -->
-            </dependency>
-            <dependency>
               <groupId>org.apache.maven.release</groupId>
               <artifactId>maven-release-oddeven-policy</artifactId>
               <version>3.0.0-M5</version>


### PR DESCRIPTION
maven release plugin was complaining

`[ERROR] Failed to execute goal org.apache.maven.plugins:maven-release-plugin:2.5.3:prepare (default-cli) on project aio-lib-java: Execution default-cli of goal org.apache.maven.plugins:maven-release-plugin:2.5.3:prepare failed: An API incompatibility was encountered while executing org.apache.maven.plugins:maven-release-plugin:2.5.3:prepare: java.lang.NoSuchMethodError: org.apache.maven.shared.invoker.InvocationRequest.setInteractive(Z)Lorg/apache/maven/shared/invoker/InvocationRequest;
[ERROR] -----------------------------------------------------
[ERROR] realm =    plugin>org.apache.maven.plugins:maven-release-plugin:2.5.3
[ERROR] strategy = org.codehaus.plexus.classworlds.strategy.SelfFirstStrategy
[ERROR] urls[0] = file:/Users/ledroff/.m2/repository/org/apache/maven/plugins/maven-release-plugin/2.5.3/maven-release-plugin-2.5.3.jar
[ERROR] urls[1] = file:/Users/ledroff/.m2/repository/org/apache/maven/shared/maven-invoker/3.1.0/maven-invoker-3.1.0.jar
`
