### PR TITLE
GH-102 mapping the new Provider Registration input model allowing to specify the `event_delivery_format`

### DIFF
--- a/aem/events_mgmt_aem/src/main/java/com/adobe/aio/aem/event/management/internal/EventProviderConfigSupplierImpl.java
+++ b/aem/events_mgmt_aem/src/main/java/com/adobe/aio/aem/event/management/internal/EventProviderConfigSupplierImpl.java
@@ -121,6 +121,7 @@ public class EventProviderConfigSupplierImpl implements EventProviderConfigSuppl
         .description(providerConfig.aio_provider_description().isEmpty() ? "AEM " + instanceId
             : providerConfig.aio_provider_description())
         .docsUrl(providerConfig.aio_provider_docs_url())
+        .eventDeliveryFormat(providerConfig.event_delivery_format())
         .build();
   }
 

--- a/aem/events_mgmt_aem/src/main/java/com/adobe/aio/aem/event/management/ocd/EventProviderConfig.java
+++ b/aem/events_mgmt_aem/src/main/java/com/adobe/aio/aem/event/management/ocd/EventProviderConfig.java
@@ -11,6 +11,8 @@
  */
 package com.adobe.aio.aem.event.management.ocd;
 
+import static com.adobe.aio.event.management.model.ProviderInputModel.DELIVERY_FORMAT_CLOUD_EVENTS_V1;
+
 import org.osgi.service.metatype.annotations.AttributeDefinition;
 import org.osgi.service.metatype.annotations.ObjectClassDefinition;
 
@@ -34,5 +36,10 @@ public @interface EventProviderConfig {
   @AttributeDefinition(name = "Event Provider Documentation URL (Optional)",
       description = "your custom documentation URL")
   String aio_provider_docs_url() default "https://developer.adobe.com/events/docs/guides/using/aem/";
+
+  @AttributeDefinition(name = "Event Delivery Format",
+      description = "Event Delivery Format: either the old legacy`adobe_io` format (used in AIO former AEM integration)"
+          + " or better the `cloud_events_v1` open specification (see https://github.com/cloudevents/spec/blob/v1.0/spec.md)")
+  String event_delivery_format() default DELIVERY_FORMAT_CLOUD_EVENTS_V1;
 
 }

--- a/events_journal/src/test/java/com/adobe/aio/event/management/feign/FeignProviderServiceIntegrationTest.java
+++ b/events_journal/src/test/java/com/adobe/aio/event/management/feign/FeignProviderServiceIntegrationTest.java
@@ -11,6 +11,10 @@
  */
 package com.adobe.aio.event.management.feign;
 
+import static com.adobe.aio.event.management.model.ProviderInputModel.DELIVERY_FORMAT_ADOBE_IO;
+import static com.adobe.aio.event.management.model.ProviderInputModel.DELIVERY_FORMAT_CLOUD_EVENTS_V1;
+import static com.adobe.aio.util.Constants.CUSTOM_EVENTS_PROVIDER_METADATA_ID;
+
 import com.adobe.aio.event.management.ProviderService;
 import com.adobe.aio.event.management.model.EventMetadata;
 import com.adobe.aio.event.management.model.Provider;
@@ -69,6 +73,8 @@ public class FeignProviderServiceIntegrationTest {
     Assert.assertEquals(WorkspaceUtil.getSystemProperty(Workspace.IMS_ORG_ID),
         provider.get().getPublisher());
     Assert.assertEquals(CloudEvent.SOURCE_URN_PREFIX + provider.get().getId(), provider.get().getSource());
+    Assert.assertEquals(DELIVERY_FORMAT_CLOUD_EVENTS_V1,provider.get().getEventDeliveryFormat());
+    Assert.assertEquals(CUSTOM_EVENTS_PROVIDER_METADATA_ID,provider.get().getProviderMetadata());
 
     Optional<EventMetadata> eventMetadata = providerService.createEventMetadata(providerId,
         getTestEventMetadataBuilder().build());
@@ -181,11 +187,14 @@ public class FeignProviderServiceIntegrationTest {
     Optional<Provider> updatedProvider = providerService.createOrUpdateProvider
         (getTestProviderInputModelBuilder()
             .instanceId(instanceId)
-            .description(updatedProviderDescription).build());
+            .description(updatedProviderDescription)
+            .eventDeliveryFormat(DELIVERY_FORMAT_ADOBE_IO)
+            .build());
     Assert.assertTrue(updatedProvider.isPresent());
     logger.info("Updated AIO Events Provider: {}", provider);
     Assert.assertEquals(providerId, updatedProvider.get().getId());
     Assert.assertEquals(updatedProviderDescription, updatedProvider.get().getDescription());
+    Assert.assertEquals(DELIVERY_FORMAT_ADOBE_IO, updatedProvider.get().getEventDeliveryFormat());
 
     providerService.createEventMetadata(providerId, getTestEventMetadataBuilder().build());
     Assert.assertTrue(eventMetadata.isPresent());

--- a/events_mgmt/src/main/java/com/adobe/aio/event/management/model/Provider.java
+++ b/events_mgmt/src/main/java/com/adobe/aio/event/management/model/Provider.java
@@ -44,6 +44,12 @@ public class Provider {
   @JsonProperty("publisher")
   private String publisher;
 
+  @JsonProperty("provider_metadata")
+  protected String providerMetadata;
+
+  @JsonProperty("event_delivery_format")
+  protected String eventDeliveryFormat;
+
   /**
    * the associated EventMetadata can be eager loaded by the provider http API
    */
@@ -120,6 +126,24 @@ public class Provider {
     return publisher;
   }
 
+  /**
+   * @return an provider_metadata id defining the type of provider
+   */
+  public String getProviderMetadata() {
+    return providerMetadata;
+  }
+
+  /**
+   *
+   * @return the Event Delivery Format, either: the old legacy`adobe_io` format
+   * or better `cloud_events_v1` (see https://github.com/cloudevents/spec/blob/v1.0/spec.md),
+   * @see ProviderInputModel#DELIVERY_FORMAT_ADOBE_IO
+   * @see ProviderInputModel##DELIVERY_FORMAT_CLOUD_EVENTS_V1
+   */
+  public String getEventDeliveryFormat() {
+    return eventDeliveryFormat;
+  }
+
   public EventMetadataCollection.EventMetadataList getEmbeddedEventMetadata() {
     return embeddedEventMetadata;
   }
@@ -139,20 +163,20 @@ public class Provider {
       return false;
     }
     Provider provider = (Provider) o;
-    return Objects.equals(id, provider.id) &&
-        Objects.equals(label, provider.label) &&
-        Objects.equals(description, provider.description) &&
-        Objects.equals(instanceId, provider.instanceId) &&
-        Objects.equals(source, provider.source) &&
-        Objects.equals(docsUrl, provider.docsUrl) &&
-        Objects.equals(publisher, provider.publisher) &&
-        Objects.equals(embeddedEventMetadata, provider.embeddedEventMetadata);
+    return Objects.equals(id, provider.id) && Objects.equals(label,
+        provider.label) && Objects.equals(description, provider.description)
+        && Objects.equals(instanceId, provider.instanceId) && Objects.equals(
+        source, provider.source) && Objects.equals(docsUrl, provider.docsUrl)
+        && Objects.equals(publisher, provider.publisher) && Objects.equals(
+        providerMetadata, provider.providerMetadata) && Objects.equals(eventDeliveryFormat,
+        provider.eventDeliveryFormat) && Objects.equals(embeddedEventMetadata,
+        provider.embeddedEventMetadata);
   }
 
   @Override
   public int hashCode() {
-    return Objects
-        .hash(id, label, description, instanceId, source, docsUrl, publisher, embeddedEventMetadata);
+    return Objects.hash(id, label, description, instanceId, source, docsUrl, publisher,
+        providerMetadata, eventDeliveryFormat, embeddedEventMetadata);
   }
 
   @Override
@@ -165,7 +189,9 @@ public class Provider {
         ", source='" + source + '\'' +
         ", docsUrl='" + docsUrl + '\'' +
         ", publisher='" + publisher + '\'' +
-        ", eventMetadata=" + embeddedEventMetadata +
+        ", providerMetadata='" + providerMetadata + '\'' +
+        ", eventDeliveryFormat='" + eventDeliveryFormat + '\'' +
+        ", embeddedEventMetadata=" + embeddedEventMetadata +
         '}';
   }
 }

--- a/events_mgmt/src/main/java/com/adobe/aio/event/management/model/ProviderInputModel.java
+++ b/events_mgmt/src/main/java/com/adobe/aio/event/management/model/ProviderInputModel.java
@@ -30,6 +30,15 @@ import org.apache.commons.lang3.StringUtils;
 public class ProviderInputModel {
 
   /**
+   * Default legacy Adobe I/O Event envelope format (`event_id` --> UUID and `event` --> payload)
+   */
+  public static final String DELIVERY_FORMAT_ADOBE_IO = "adobe_io";
+  /**
+   * CloudEvents V1 Event envelop format see https://github.com/cloudevents/spec/blob/v1.0/spec.md
+   */
+  public static final String DELIVERY_FORMAT_CLOUD_EVENTS_V1 = "cloud_events_v1";
+
+  /**
    * Optional key when creating/POST-ing a new provider.
    * Note it will be ignored when updating/PUT-ing it.
    * If none is provided our API will create a Random UUID for you.
@@ -47,6 +56,16 @@ public class ProviderInputModel {
   @JsonProperty("provider_metadata")
   private final String providerMetadataId;
 
+  /** Optional Event Delivery Format, either: the old legacy`adobe_io` format
+   * or better `cloud_events_v1` (see https://github.com/cloudevents/spec/blob/v1.0/spec.md),
+   * this is optional, if none is provided a default event delivery format is associated with
+   * your provider_metadata on the Adobe I/O side. It is `cloud_events_v1` for `Custom Events` Provider
+   * @see #DELIVERY_FORMAT_ADOBE_IO
+   * @see #DELIVERY_FORMAT_CLOUD_EVENTS_V1
+  */
+  @JsonProperty("event_delivery_format")
+  private final String eventDeliveryFormat;
+
   /**
    * The label of this Events Provider, as shown on the Adobe I/O console
    */
@@ -59,7 +78,7 @@ public class ProviderInputModel {
   private final String docsUrl;
 
   private ProviderInputModel(final String label, final String description, final String docsUrl, final String instanceId,
-      final String providerMetadataId) {
+      final String providerMetadataId, final String eventDeliveryFormat) {
     if (StringUtils.isEmpty(label)) {
       throw new IllegalArgumentException(
           "ProviderUpdateModel is missing a label");
@@ -70,6 +89,7 @@ public class ProviderInputModel {
     this.description = description;
     this.docsUrl = docsUrl;
     this.instanceId = instanceId;
+    this.eventDeliveryFormat = eventDeliveryFormat;
   }
 
   public String getLabel() {
@@ -88,6 +108,8 @@ public class ProviderInputModel {
 
   public String getProviderMetadataId() { return this.providerMetadataId; }
 
+  public String getEventDeliveryFormat() { return this.eventDeliveryFormat; }
+
   @Override
   public boolean equals(Object o) {
     if (this == o) {
@@ -98,13 +120,14 @@ public class ProviderInputModel {
     }
     ProviderInputModel that = (ProviderInputModel) o;
     return Objects.equals(instanceId, that.instanceId) && Objects.equals(providerMetadataId,
-        that.providerMetadataId) && Objects.equals(label, that.label) && Objects.equals(
+        that.providerMetadataId) && Objects.equals(eventDeliveryFormat,
+        that.eventDeliveryFormat) && Objects.equals(label, that.label) && Objects.equals(
         description, that.description) && Objects.equals(docsUrl, that.docsUrl);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(instanceId, providerMetadataId, label, description, docsUrl);
+    return Objects.hash(instanceId, providerMetadataId, label, description, docsUrl, eventDeliveryFormat);
   }
 
   @Override
@@ -115,6 +138,7 @@ public class ProviderInputModel {
         ", docsUrl='" + docsUrl + '\'' +
         ", providerMetadataId='" + providerMetadataId + '\'' +
         ", instanceId='" + instanceId + '\'' +
+        ", eventDeliveryFormat='" + eventDeliveryFormat + '\'' +
         '}';
   }
 
@@ -130,6 +154,7 @@ public class ProviderInputModel {
     private String docsUrl;
     private String instanceId;
     private String providerMetadataId;
+    private String eventDeliveryFormat;
 
     public Builder() {
     }
@@ -159,8 +184,13 @@ public class ProviderInputModel {
       return this;
     }
 
+    public Builder eventDeliveryFormat(final String eventDeliveryFormat) {
+      this.eventDeliveryFormat = eventDeliveryFormat;
+      return this;
+    }
+
     public ProviderInputModel build() {
-      return new ProviderInputModel(label, description, docsUrl, instanceId, providerMetadataId);
+      return new ProviderInputModel(label, description, docsUrl, instanceId, providerMetadataId, eventDeliveryFormat);
     }
   }
 }

--- a/ims/src/main/java/com/adobe/aio/util/WorkspaceUtil.java
+++ b/ims/src/main/java/com/adobe/aio/util/WorkspaceUtil.java
@@ -43,7 +43,7 @@ public class WorkspaceUtil {
         System.getProperty(Workspace.META_SCOPES),
         System.getProperty(Workspace.PROJECT_ID),
         System.getProperty(Workspace.TECHNICAL_ACCOUNT_ID))) {
-      logger.debug("loading test Workspace from JVM System Properties");
+      logger.info("loading test Workspace from JVM System Properties");
       PrivateKey privateKey = new PrivateKeyBuilder().encodedPkcs8Key(
           System.getProperty(PrivateKeyBuilder.AIO_ENCODED_PKCS_8)).build();
       return Workspace.builder()
@@ -53,7 +53,7 @@ public class WorkspaceUtil {
       /**
        * WARNING: don't push back your workspace secrets to github
        */
-      logger.debug("loading test Workspace from classpath {}", DEFAULT_TEST_PROPERTIES);
+      logger.info("loading test Workspace from classpath {}", DEFAULT_TEST_PROPERTIES);
       return getWorkspaceBuilder(DEFAULT_TEST_PROPERTIES);
     }
   }

--- a/ims/src/main/java/com/adobe/aio/util/WorkspaceUtil.java
+++ b/ims/src/main/java/com/adobe/aio/util/WorkspaceUtil.java
@@ -43,7 +43,7 @@ public class WorkspaceUtil {
         System.getProperty(Workspace.META_SCOPES),
         System.getProperty(Workspace.PROJECT_ID),
         System.getProperty(Workspace.TECHNICAL_ACCOUNT_ID))) {
-      logger.info("loading test Workspace from JVM System Properties");
+      logger.debug("loading test Workspace from JVM System Properties");
       PrivateKey privateKey = new PrivateKeyBuilder().encodedPkcs8Key(
           System.getProperty(PrivateKeyBuilder.AIO_ENCODED_PKCS_8)).build();
       return Workspace.builder()
@@ -53,7 +53,7 @@ public class WorkspaceUtil {
       /**
        * WARNING: don't push back your workspace secrets to github
        */
-      logger.info("loading test Workspace from classpath {}", DEFAULT_TEST_PROPERTIES);
+      logger.debug("loading test Workspace from classpath {}", DEFAULT_TEST_PROPERTIES);
       return getWorkspaceBuilder(DEFAULT_TEST_PROPERTIES);
     }
   }


### PR DESCRIPTION
see https://github.com/adobe/aio-lib-java/issues/102

* mapping the new Provider Registration input model allowing to specify the `event_delivery_format`
* adding `event_delivery_format` in the AEM OSGI Provider configurations
  * default being now `cloud_events_v1` instead of the old legacy `adobe_io` format

replacing https://github.com/adobe/aio-lib-java/pull/119 to have the secrets available for integration tests to run