### PR TITLE
GH-21 and GH-104 jdk8 support and move of the xdm IO Events Model here as a new module

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 ## Modules
 
-This project is composed of Java Libraries :
+This project is composed of a few Java Libraries, among these :
 * [`aio-lib-java-core`](./core)  holds the core models, builders, utilities used across the other libraries below,
 * [`aio-lib-java-ims`](./ims) is a library wrapping a subset of [Adobe Identity Management System (IMS) API](https://www.adobe.io/authentication/auth-methods.html#!AdobeDocs/adobeio-auth/master/AuthenticationOverview/AuthenticationGuide.md)
 * [`aio-lib-java-events-mgmt`](./events_mgmt) is a library wrapping [Adobe I/O Events Provider and Registration API](https://www.adobe.io/apis/experienceplatform/events/docs.html#!adobedocs/adobeio-events/master/api/api.md)

--- a/aem/core_aem/pom.xml
+++ b/aem/core_aem/pom.xml
@@ -55,7 +55,7 @@
     <!-- test -->
     <dependency>
       <groupId>junit</groupId>
-      <artifactId>junit-dep</artifactId>
+      <artifactId>junit</artifactId>
     </dependency>
     <dependency>
       <groupId>org.slf4j</groupId>

--- a/aem/events_ingress_aem/pom.xml
+++ b/aem/events_ingress_aem/pom.xml
@@ -54,7 +54,7 @@
 
     <!-- test -->
     <dependency>
-      <artifactId>junit-dep</artifactId>
+      <artifactId>junit</artifactId>
       <groupId>junit</groupId>
     </dependency>
     <dependency>

--- a/aem/events_mgmt_aem/pom.xml
+++ b/aem/events_mgmt_aem/pom.xml
@@ -42,7 +42,7 @@
 
     <!-- test -->
     <dependency>
-      <artifactId>junit-dep</artifactId>
+      <artifactId>junit</artifactId>
       <groupId>junit</groupId>
     </dependency>
     <dependency>

--- a/aem/events_osgi_mapping/pom.xml
+++ b/aem/events_osgi_mapping/pom.xml
@@ -52,12 +52,13 @@
       <scope>provided</scope>
       <version>${project.version}</version>
     </dependency>
-    <!-- adobe.io XDM event model -->
     <dependency>
-      <artifactId>xdm-event-model</artifactId>
-      <groupId>com.adobe.event</groupId>
+      <groupId>com.adobe.aio</groupId>
+      <artifactId>aio-lib-java-events-xdm</artifactId>
       <scope>provided</scope>
+      <version>${project.version}</version>
     </dependency>
+
 
     <!-- test -->
     <dependency>

--- a/aem/events_osgi_mapping/pom.xml
+++ b/aem/events_osgi_mapping/pom.xml
@@ -62,7 +62,7 @@
 
     <!-- test -->
     <dependency>
-      <artifactId>junit-dep</artifactId>
+      <artifactId>junit</artifactId>
       <groupId>junit</groupId>
     </dependency>
     <dependency>

--- a/aem/lib_osgi/pom.xml
+++ b/aem/lib_osgi/pom.xml
@@ -26,16 +26,12 @@
   <name>Adobe I/O - Java SDK - OSGI bundle</name>
 
   <dependencies>
-    <dependency> <!-- TODO: Remove this when xdm-event-model no longer depends on it -->
-      <groupId>javax.validation</groupId>
-      <artifactId>validation-api</artifactId>
-      <version>2.0.1.Final</version>
-    </dependency>
-    <dependency>
-      <groupId>com.adobe.event</groupId>
-      <artifactId>xdm-event-model</artifactId>
-    </dependency>
 
+    <dependency>
+      <groupId>com.adobe.aio</groupId>
+      <artifactId>aio-lib-java-events-xdm</artifactId>
+      <version>${project.version}</version>
+    </dependency>
     <dependency>
       <groupId>com.adobe.aio</groupId>
       <artifactId>aio-lib-java-ims</artifactId>

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -57,9 +57,8 @@
 
     <dependency>
       <groupId>junit</groupId>
-      <artifactId>junit-dep</artifactId>
+      <artifactId>junit</artifactId>
     </dependency>
-
     <dependency>
       <groupId>org.slf4j</groupId>
       <artifactId>slf4j-simple</artifactId>

--- a/core/src/test/java/com/adobe/aio/util/FileUtilTest.java
+++ b/core/src/test/java/com/adobe/aio/util/FileUtilTest.java
@@ -14,6 +14,8 @@ package com.adobe.aio.util;
 import static org.junit.Assert.assertEquals;
 
 import com.adobe.aio.util.FileUtil;
+
+import java.util.HashMap;
 import java.util.Map;
 import java.util.Properties;
 import org.junit.Assert;
@@ -33,14 +35,15 @@ public class FileUtilTest {
 
   @Test
   public void testGetMapFromProperties() {
-    assertEquals(Map.ofEntries(Map.entry(KEY, VALUE)),
-        FileUtil.getMapFromProperties(getTestProperties()));
+    Map<String, String> map = new HashMap<>();
+    map.put(KEY, VALUE);
+    assertEquals(map, FileUtil.getMapFromProperties(getTestProperties()));
   }
 
   @Test
   public void testReadPropertiesFromFile() {
-    Assert.assertTrue(FileUtil.readPropertiesFromFile("").isEmpty());
-    Assert.assertTrue(FileUtil.readPropertiesFromFile(null).isEmpty());
+    Assert.assertFalse(FileUtil.readPropertiesFromFile("").isPresent());
+    Assert.assertFalse(FileUtil.readPropertiesFromFile(null).isPresent());
   }
 
   @Test

--- a/events_ingress/pom.xml
+++ b/events_ingress/pom.xml
@@ -37,7 +37,7 @@
     <!--  test -->
     <dependency>
       <groupId>junit</groupId>
-      <artifactId>junit-dep</artifactId>
+      <artifactId>junit</artifactId>
     </dependency>
     <dependency>
       <groupId>org.slf4j</groupId>

--- a/events_journal/pom.xml
+++ b/events_journal/pom.xml
@@ -49,7 +49,7 @@
     </dependency>
     <dependency>
       <groupId>junit</groupId>
-      <artifactId>junit-dep</artifactId>
+      <artifactId>junit</artifactId>
     </dependency>
     <dependency>
       <groupId>com.squareup.okhttp3</groupId>

--- a/events_mgmt/pom.xml
+++ b/events_mgmt/pom.xml
@@ -37,7 +37,7 @@
     <!--  test -->
     <dependency>
       <groupId>junit</groupId>
-      <artifactId>junit-dep</artifactId>
+      <artifactId>junit</artifactId>
     </dependency>
     <dependency>
       <groupId>org.slf4j</groupId>

--- a/events_test/README.md
+++ b/events_test/README.md
@@ -1,0 +1,19 @@
+# `aio-lib-java-events-test`
+
+`aio-lib-java-events-test` is Adobe I/O - Java SDK - Events Test Utility Library.
+
+Its `src/test/java` folder also contains a set of `*IntegrationTest` ran by this repository's GitHub Actions.
+
+## Builds
+
+This Library is build with [maven](https://maven.apache.org/) (it also runs the unit tests):
+
+### Contributing
+
+Contributions are welcomed! Read the [Contributing Guide](../.github/CONTRIBUTING.md) for more information.
+
+### Licensing
+
+This project is licensed under the Apache V2 License. See [LICENSE](../LICENSE.md) for more information.
+
+  

--- a/events_test/pom.xml
+++ b/events_test/pom.xml
@@ -56,7 +56,7 @@
 
     <dependency>
       <groupId>junit</groupId>
-      <artifactId>junit-dep</artifactId>
+      <artifactId>junit</artifactId>
       <scope>compile</scope>
     </dependency>
     <dependency>

--- a/events_test/src/main/java/com/adobe/aio/event/management/ProviderServiceTester.java
+++ b/events_test/src/main/java/com/adobe/aio/event/management/ProviderServiceTester.java
@@ -103,7 +103,7 @@ public class ProviderServiceTester {
       Assert.assertEquals(eventMetadataInput.getEventCode(), eventMetadata.get().getEventCode());
       Assert.assertEquals(eventMetadataInput.getDescription(),
           eventMetadata.get().getDescription());
-      Assert.assertEquals(eventMetadataInput.getEventCode(), eventMetadata.get().getLabel());
+      Assert.assertEquals(eventMetadataInput.getLabel(), eventMetadata.get().getLabel());
       logger.info("Added EventMetadata `{}` to AIO Events Provider `{}`", eventMetadata,
           providerId);
     }

--- a/events_test/src/main/java/com/adobe/aio/event/management/ProviderServiceTester.java
+++ b/events_test/src/main/java/com/adobe/aio/event/management/ProviderServiceTester.java
@@ -17,6 +17,8 @@ import com.adobe.aio.event.management.model.ProviderInputModel;
 import com.adobe.aio.event.publish.model.CloudEvent;
 import com.adobe.aio.util.WorkspaceUtil;
 import com.adobe.aio.workspace.Workspace;
+
+import java.util.Collections;
 import java.util.Optional;
 import java.util.Set;
 import java.util.function.Supplier;
@@ -59,7 +61,7 @@ public class ProviderServiceTester {
 
   public Provider createOrUpdateProvider(String providerLabel, String eventCode) {
     return createOrUpdateProvider(getTestProviderInputModelBuilder(providerLabel).build(),
-        Set.of(getTestEventMetadataBuilder(eventCode).build()));
+        Collections.singleton(getTestEventMetadataBuilder(eventCode).build()));
   }
 
   public Provider createOrUpdateProvider(ProviderInputModel providerInputModel,
@@ -112,7 +114,7 @@ public class ProviderServiceTester {
     providerService.deleteProvider(providerId);
     logger.info("Deleted AIO Events Provider: {}", providerId);
     Optional deleted = providerService.findProviderById(providerId);
-    Assert.assertTrue(deleted.isEmpty());
+    Assert.assertFalse(deleted.isPresent());
     logger.info("No more AIO Events Provider with id: {}", providerId);
   }
 

--- a/events_test/src/main/java/com/adobe/aio/event/management/RegistrationServiceTester.java
+++ b/events_test/src/main/java/com/adobe/aio/event/management/RegistrationServiceTester.java
@@ -91,7 +91,7 @@ public class RegistrationServiceTester {
 
   public void deleteRegistration(String registrationId) {
     registrationService.delete(registrationId);
-    Assert.assertTrue(registrationService.findById(registrationId).isEmpty());
+    Assert.assertFalse(registrationService.findById(registrationId).isPresent());
     logger.info("Deleted AIO Event Registration: {}", registrationId);
   }
 

--- a/events_test/src/test/java/com/adobe/aio/event/management/ProviderServiceIntegrationTest.java
+++ b/events_test/src/test/java/com/adobe/aio/event/management/ProviderServiceIntegrationTest.java
@@ -54,10 +54,10 @@ public class ProviderServiceIntegrationTest extends ProviderServiceTester {
   @Test
   public void getNotFound() {
     String idNotToBeFound = "this_id_should_not_exist";
-    Assert.assertTrue(providerService.findProviderById(idNotToBeFound).isEmpty());
+    Assert.assertFalse(providerService.findProviderById(idNotToBeFound).isPresent());
     Assert.assertTrue(providerService.getEventMetadata(idNotToBeFound).isEmpty());
-    Assert.assertTrue(
-        providerService.findCustomEventsProviderByInstanceId(idNotToBeFound).isEmpty());
+    Assert.assertFalse(
+        providerService.findCustomEventsProviderByInstanceId(idNotToBeFound).isPresent());
   }
 
   @Test
@@ -100,7 +100,7 @@ public class ProviderServiceIntegrationTest extends ProviderServiceTester {
       logger.info("Found AIO Events Provider `{}` by InstanceId", providerById);
 
       providerService.deleteEventMetadata(providerId, TEST_EVENT_CODE);
-      Assert.assertTrue(providerService.getEventMetadata(providerId, TEST_EVENT_CODE).isEmpty());
+      Assert.assertFalse(providerService.getEventMetadata(providerId, TEST_EVENT_CODE).isPresent());
       Assert.assertTrue(providerService.getEventMetadata(providerId).isEmpty());
       logger.info("Deleted EventMetadata {} from AIO Events Provider `{}`", TEST_EVENT_CODE,
           providerById);

--- a/events_test/src/test/java/com/adobe/aio/event/management/RegistrationServiceIntegrationTest.java
+++ b/events_test/src/test/java/com/adobe/aio/event/management/RegistrationServiceIntegrationTest.java
@@ -40,7 +40,7 @@ public class RegistrationServiceIntegrationTest extends RegistrationServiceTeste
   @Test
   public void getNotFound() {
     String idNotToBeFound = "this_id_should_not_exist";
-    Assert.assertTrue(registrationService.findById(idNotToBeFound).isEmpty());
+    Assert.assertFalse(registrationService.findById(idNotToBeFound).isPresent());
   }
 
   @Test

--- a/events_xdm/README.md
+++ b/events_xdm/README.md
@@ -1,0 +1,36 @@
+# `aio-lib-java-events-xdm`
+
+`aio-lib-java-events-xdm` is Adobe I/O - Java SDK - Jackson based implementation of the Adobe XDM Event Envelope Model.
+
+This Adobe XDM Event Envelope Model is 
+based on [json-ld w3c activity streams spec](https://github.com/w3c/activitystreams/blob/master/ns/activitystreams.jsonld),
+for more detailed specifications, 
+visit the [Adobe XDM event envelope schema](https://github.com/adobe/xdm/blob/master/archived/common/eventenvelope.schema.json)
+
+## `json-ld` notes and pointers
+
+Note that as we chose to serve the json-ld `@context` through link header [9] and keep fixed json-ld prefixes,
+we based this implementation of plain and simple jackson [10] serialization,
+otherwise for full-fledged json-ld implementation hydra [0] and jsonld-java [8] could have been used
+
+* [0] http://www.hydra-cg.com/
+* [1] https://github.com/dschulten/hydra-java
+* [2] https://github.com/dschulten/hydra-java/tree/master/hydra-jsonld
+* [3] https://json-ld.org/playground/
+* [4] https://github.com/w3c/activitystreams/issues/134#issuecomment-108122077
+* [5] https://github.com/w3c/activitystreams/issues/136
+* [8] https://github.com/jsonld-java/jsonld-java
+* [9] https://www.w3.org/TR/json-ld/#interpreting-json-as-json-ld
+* [10] https://github.com/FasterXML/jackson-core
+
+## Builds
+
+This Library is build with [maven](https://maven.apache.org/) (it also runs the unit tests):
+
+### Contributing
+
+Contributions are welcomed! Read the [Contributing Guide](../.github/CONTRIBUTING.md) for more information.
+
+### Licensing
+
+This project is licensed under the Apache V2 License. See [LICENSE](../LICENSE.md) for more information.

--- a/events_xdm/pom.xml
+++ b/events_xdm/pom.xml
@@ -1,0 +1,67 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Copyright 2017 Adobe. All rights reserved.
+    This file is licensed to you under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License. You may obtain a copy
+    of the License at http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software distributed under
+    the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+    OF ANY KIND, either express or implied. See the License for the specific language
+    governing permissions and limitations under the License.
+
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+
+  <parent>
+    <groupId>com.adobe.aio</groupId>
+    <artifactId>aio-lib-java</artifactId>
+    <version>0.1.5-SNAPSHOT</version>
+    <relativePath>../pom.xml</relativePath>
+  </parent>
+  <modelVersion>4.0.0</modelVersion>
+
+  <artifactId>aio-lib-java-events-xdm</artifactId>
+  <name>Adobe I/O - XDM Event Model</name>
+  <description>Adobe I/O - Java SDK - (Jackson based) Implementation of the Adobe XDM Event Model</description>
+
+  <dependencies>
+    <dependency>
+      <groupId>com.fasterxml.jackson.core</groupId>
+      <artifactId>jackson-annotations</artifactId>
+      <scope>provided</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>com.fasterxml.jackson.core</groupId>
+      <artifactId>jackson-databind</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>junit</groupId>
+      <artifactId>junit-dep</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.slf4j</groupId>
+      <artifactId>slf4j-simple</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.hamcrest</groupId>
+      <artifactId>hamcrest-all</artifactId>
+      <version>1.3</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>com.jayway.jsonpath</groupId>
+      <artifactId>json-path-assert</artifactId>
+      <version>0.9.1</version>
+      <scope>test</scope>
+    </dependency>
+
+  </dependencies>
+
+</project>
+

--- a/events_xdm/pom.xml
+++ b/events_xdm/pom.xml
@@ -40,7 +40,7 @@
     </dependency>
     <dependency>
       <groupId>junit</groupId>
-      <artifactId>junit-dep</artifactId>
+      <artifactId>junit</artifactId>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/events_xdm/src/main/java/com/adobe/xdm/Xdm.java
+++ b/events_xdm/src/main/java/com/adobe/xdm/Xdm.java
@@ -1,0 +1,24 @@
+/*
+ * Copyright 2017 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+package com.adobe.xdm;
+
+import com.adobe.xdm.common.XdmContext;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+public class Xdm {
+
+  @JsonProperty("@context")
+  public XdmContext getXdmContext() {
+    return new XdmContext();
+  }
+
+}

--- a/events_xdm/src/main/java/com/adobe/xdm/XdmObject.java
+++ b/events_xdm/src/main/java/com/adobe/xdm/XdmObject.java
@@ -1,0 +1,78 @@
+/*
+ * Copyright 2017 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+package com.adobe.xdm;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonInclude.Include;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+/**
+ * ActivityStreams Object
+ */
+@JsonInclude(Include.NON_NULL)
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class XdmObject {
+
+  protected String id;
+  protected String type;
+
+  @JsonProperty("@id")
+  public String getId() {
+    return id;
+  }
+
+  public void setId(String id) {
+    this.id = id;
+  }
+
+  @JsonProperty("@type")
+  public String getType() {
+    return type;
+  }
+
+  public void setType(String type) {
+    this.type = type;
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+
+    XdmObject that = (XdmObject) o;
+
+    if (id != null ? !id.equals(that.id) : that.id != null) {
+      return false;
+    }
+    return type != null ? type.equals(that.type) : that.type == null;
+  }
+
+  @Override
+  public int hashCode() {
+    int result = id != null ? id.hashCode() : 0;
+    result = 31 * result + (type != null ? type.hashCode() : 0);
+    return result;
+  }
+
+  @Override
+  public String toString() {
+    return "XdmObject{" +
+        "id='" + id + '\'' +
+        ", type='" + type + '\'' +
+        '}';
+  }
+}

--- a/events_xdm/src/main/java/com/adobe/xdm/assets/Asset.java
+++ b/events_xdm/src/main/java/com/adobe/xdm/assets/Asset.java
@@ -1,0 +1,134 @@
+/*
+ * Copyright 2017 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+package com.adobe.xdm.assets;
+
+import com.adobe.xdm.XdmObject;
+import com.adobe.xdm.common.XdmContext;
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonInclude.Include;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+@JsonInclude(Include.NON_NULL)
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class Asset extends XdmObject {
+
+  private String assetId;
+
+  private String assetName;
+
+  private String etag;
+
+  private String path;
+
+  private String format;
+
+
+  public Asset() {
+    super();
+    this.type = XdmContext.XDM_ASSET_TYPE;
+  }
+
+  @JsonProperty(XdmContext.XDM_ASSET_PREFIX + ":asset_id")
+  public String getAssetId() {
+    return this.assetId;
+  }
+
+  public void setAssetId(String assetId) {
+    this.assetId = assetId;
+  }
+
+  @JsonProperty(XdmContext.XDM_ASSET_PREFIX + ":asset_name")
+  public String getAssetName() {
+    return assetName;
+  }
+
+  public void setAssetName(String assetName) {
+    this.assetName = assetName;
+  }
+
+  @JsonProperty(XdmContext.XDM_ASSET_PREFIX + ":etag")
+  public String getEtag() {
+    return etag;
+  }
+
+  public void setEtag(String etag) {
+    this.etag = etag;
+  }
+
+  @JsonProperty(XdmContext.XDM_ASSET_PREFIX + ":path")
+  public String getPath() {
+    return path;
+  }
+
+  public void setPath(String path) {
+    this.path = path;
+  }
+
+  @JsonProperty(XdmContext.XDM_ASSET_PREFIX + ":format")
+  public String getFormat() {
+    return this.format;
+  }
+
+  public void setFormat(String format) {
+    this.format = format;
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    if (!super.equals(o)) {
+      return false;
+    }
+
+    Asset asset = (Asset) o;
+
+    if (assetName != null ? !assetName.equals(asset.assetName) : asset.assetName != null) {
+      return false;
+    }
+    if (etag != null ? !etag.equals(asset.etag) : asset.etag != null) {
+      return false;
+    }
+    if (path != null ? !path.equals(asset.path) : asset.path != null) {
+      return false;
+    }
+    return format != null ? format.equals(asset.format) : asset.format == null;
+  }
+
+  @Override
+  public int hashCode() {
+    int result = super.hashCode();
+    result = 31 * result + (assetName != null ? assetName.hashCode() : 0);
+    result = 31 * result + (etag != null ? etag.hashCode() : 0);
+    result = 31 * result + (path != null ? path.hashCode() : 0);
+    result = 31 * result + (format != null ? format.hashCode() : 0);
+    return result;
+  }
+
+  @Override
+  public String toString() {
+    return "Asset{" +
+        "id='" + id + '\'' +
+        ", type='" + type + '\'' +
+        ", assetId='" + assetId + '\'' +
+        ", assetName='" + assetName + '\'' +
+        ", etag='" + etag + '\'' +
+        ", path='" + path + '\'' +
+        ", format='" + format + '\'' +
+        '}';
+  }
+}

--- a/events_xdm/src/main/java/com/adobe/xdm/common/XdmContext.java
+++ b/events_xdm/src/main/java/com/adobe/xdm/common/XdmContext.java
@@ -1,0 +1,160 @@
+/*
+ * Copyright 2017 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+package com.adobe.xdm.common;
+
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+public class XdmContext {
+
+  public static final String XDM_BASE_URL = "https://ns.adobe.com/xdm";
+  public static final String XDM_EXTENSION_BASE_URL = "https://ns.adobe.com/xdm-extensions";
+
+  public static final String XDM_AEM_USER_TYPE = "xdmAemUser";
+  public static final String XDM_AEM_USER_PREFIX = XDM_AEM_USER_TYPE;
+  public static final String XDM_AEM_USER_JSONLD_IRI = XDM_EXTENSION_BASE_URL + "/aem/user";
+
+  public static final String OSGI_EVENT_TYPE = "osgiEvent";
+  public static final String OSGI_EVENT_PREFIX = OSGI_EVENT_TYPE;
+  public static final String OSGI_EVENT_JSONLD_IRI = "https://osgi.org/javadoc/r4v42/org/osgi/service/event/Event.html";
+
+  public static final String XDM_ASSET_TYPE = "xdmAsset";
+  public static final String XDM_ASSET_PREFIX = XDM_ASSET_TYPE;
+  public static final String XDM_ASSET_JSONLD_IRI = XDM_BASE_URL + "/assets/asset#";
+
+  public static final String XDM_DIRECTORY_TYPE = "xdmDirectory";
+  public static final String XDM_DIRECTORY_PREFIX = XDM_DIRECTORY_TYPE;
+  public static final String XDM_DIRECTORY_JSONLD_IRI = "https://ns.adobe.com/adobecloud/core/1.0/directory#";
+
+  public static final String XDM_IMS_ORG_TYPE = "xdmImsOrg";
+  public static final String XDM_IMS_ORG_PREFIX = XDM_IMS_ORG_TYPE;
+  public static final String XDM_IMS_ORG_JSONLD_IRI = XDM_EXTENSION_BASE_URL + "/ims/organization#";
+
+  public static final String XDM_IMS_USER_TYPE = "xdmImsUser";
+  public static final String XDM_IMS_USER_PREFIX = XDM_IMS_USER_TYPE;
+  public static final String XDM_IMS_USER_JSONLD_IRI = XDM_EXTENSION_BASE_URL + "/ims/user#";
+
+  public static final String XDM_CONTENT_REPOSITORY_TYPE = "xdmContentRepository";
+  public static final String XDM_CONTENT_REPOSITORY_PREFIX = XDM_CONTENT_REPOSITORY_TYPE;
+  public static final String XDM_CONTENT_REPOSITORY_JSONLD_IRI =
+      XDM_BASE_URL + "/content/repository#";
+
+  public static final String XDM_COMPONENTIZED_PAGE_TYPE = "xdmComponentizedPage";
+  public static final String XDM_COMPONENTIZED_PAGE_PREFIX = XDM_COMPONENTIZED_PAGE_TYPE;
+  public static final String XDM_COMPONENTIZED_PAGE_JSONLD_IRI =
+      XDM_BASE_URL + "/content/componentized-page#";
+
+  public static final String XDM_EVENT_CREATED_TYPE = "xdmCreated";
+  public static final String XDM_EVENT_CREATED_JSONLD_IRI = XDM_BASE_URL + "/common/event/created#";
+  public static final String XDM_EVENT_DELETED_TYPE = "xdmDeleted";
+  public static final String XDM_EVENT_DELETED_JSONLD_IRI = XDM_BASE_URL + "/common/event/deleted#";
+  public static final String XDM_EVENT_UPDATED_TYPE = "xdmUpdated";
+  public static final String XDM_EVENT_UPDATED_JSONLD_IRI = XDM_BASE_URL + "/common/event/updated#";
+
+  public static final String XDM_EVENT_PUBLISHED_TYPE = "xdmPublished";
+  public static final String XDM_EVENT_PUBLISHED_JSONLD_IRI = XDM_BASE_URL + "/common/event/published#";
+  public static final String XDM_EVENT_UNPUBLISHED_TYPE = "xdmUnpublished";
+  public static final String XDM_EVENT_UNPUBLISHED_JSONLD_IRI = XDM_BASE_URL + "/common/event/unpublished#";
+
+  public static final String XDM_EVENT_EMITTED_TYPE = "xdmEmitted";
+  public static final String XDM_EVENT_EMITTED_TYPE_JSONLD_IRI = XDM_BASE_URL + "/common/event/emitted#";
+
+
+  public static final String W3C_ACTIVITYSTREAMS_PREFIX = "activitystreams";
+  public static final String W3C_ACTIVITYSTREAMS_JSONLD_IRI = "http://www.w3.org/ns/activitystreams#";
+
+  public static final String XDM_EVENT_ENVELOPE_PREFIX = "xdmEventEnvelope";
+  public static final String XDM_EVENT_ENVELOPE_JSONLD_IRI = XDM_BASE_URL + "/event-envelope#";
+
+  public static final String DATE_FORMAT = "yyyy-MM-dd'T'HH:mm:ss.SSSX";
+
+  @JsonProperty(W3C_ACTIVITYSTREAMS_PREFIX)
+  public String getActivityStreamsIRI() {
+    return W3C_ACTIVITYSTREAMS_JSONLD_IRI;
+  }
+
+  @JsonProperty(XDM_EVENT_ENVELOPE_PREFIX)
+  public String getXdmEnvelopeIRI() {
+    return XDM_EVENT_ENVELOPE_JSONLD_IRI;
+  }
+
+  @JsonProperty(XDM_COMPONENTIZED_PAGE_PREFIX)
+  public String getXdmComponentizedPageIRI() {
+    return XDM_COMPONENTIZED_PAGE_JSONLD_IRI;
+  }
+
+  @JsonProperty(XDM_IMS_ORG_PREFIX)
+  public String getXdmImsOrgIRI() {
+    return XDM_IMS_ORG_JSONLD_IRI;
+  }
+
+  @JsonProperty(XDM_CONTENT_REPOSITORY_PREFIX)
+  public String getXdmContentRepositoryIRI() {
+    return XDM_CONTENT_REPOSITORY_JSONLD_IRI;
+  }
+
+  @JsonProperty(XDM_AEM_USER_PREFIX)
+  public String getXdmAemUserIRI() {
+    return XDM_AEM_USER_JSONLD_IRI;
+  }
+
+  @JsonProperty(XDM_IMS_USER_PREFIX)
+  public String getXdmImsUserIRI() {
+    return XDM_IMS_USER_JSONLD_IRI;
+  }
+
+  @JsonProperty(XDM_ASSET_PREFIX)
+  public String getXdmAssetIRI() {
+    return XDM_ASSET_JSONLD_IRI;
+  }
+
+  @JsonProperty("xdmDirectory")
+  public String getXdmDirectoryIRI() {
+    return XDM_DIRECTORY_JSONLD_IRI;
+  }
+
+  @JsonProperty(XDM_EVENT_CREATED_TYPE)
+  public String getXdmCreatedIRI() {
+    return XDM_EVENT_CREATED_JSONLD_IRI;
+  }
+
+  @JsonProperty(XDM_EVENT_UPDATED_TYPE)
+  public String getXdmUpdatedIRI() {
+    return XDM_EVENT_UPDATED_JSONLD_IRI;
+  }
+
+  @JsonProperty(XDM_EVENT_DELETED_TYPE)
+  public String getXdmDeletedIRI() {
+    return XDM_EVENT_DELETED_JSONLD_IRI;
+  }
+
+  @JsonProperty(XDM_EVENT_PUBLISHED_TYPE)
+  public String getXdmPublishedIRI() {
+    return XDM_EVENT_PUBLISHED_JSONLD_IRI;
+  }
+
+  @JsonProperty(XDM_EVENT_UNPUBLISHED_TYPE)
+  public String getXdmUnpublishedIRI() {
+    return XDM_EVENT_UNPUBLISHED_JSONLD_IRI;
+  }
+
+  @JsonProperty(XDM_EVENT_EMITTED_TYPE)
+  public String getXdmEmittedIRI() {
+    return XDM_EVENT_EMITTED_TYPE_JSONLD_IRI;
+  }
+
+  @JsonProperty(OSGI_EVENT_TYPE)
+  public String getOsgiEventdIRI() {
+    return OSGI_EVENT_JSONLD_IRI;
+  }
+
+}

--- a/events_xdm/src/main/java/com/adobe/xdm/common/XdmEvent.java
+++ b/events_xdm/src/main/java/com/adobe/xdm/common/XdmEvent.java
@@ -1,0 +1,157 @@
+/*
+ * Copyright 2017 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+package com.adobe.xdm.common;
+
+import com.adobe.xdm.XdmObject;
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class XdmEvent
+    <Ob extends XdmObject,
+        To extends XdmObject,
+        Ge extends XdmObject,
+        Ac extends XdmObject> {
+
+  protected String id;
+  protected String type;
+  protected String published;
+  protected To to;
+  protected Ge generator;
+  protected Ac actor;
+  protected Ob object;
+
+  @JsonProperty("@id")
+  public String getId() {
+    return id;
+  }
+
+  public void setId(String id) {
+    this.id = id;
+  }
+
+  @JsonProperty("@type")
+  public String getType() {
+    return type;
+  }
+
+  public void setType(String type) {
+    this.type = type;
+  }
+
+  @JsonProperty(XdmContext.XDM_EVENT_ENVELOPE_PREFIX + ":objectType")
+  public String getObjectType() {
+    return (object == null) ? null : object.getType();
+  }
+
+  @JsonProperty(XdmContext.W3C_ACTIVITYSTREAMS_PREFIX + ":published")
+  public String getPublished() {
+    return published;
+  }
+
+  public void setPublished(String published) {
+    this.published = published;
+  }
+
+  @JsonProperty(XdmContext.W3C_ACTIVITYSTREAMS_PREFIX + ":to")
+  public To getTo() {
+    return to;
+  }
+
+  public void setTo(To to) {
+    this.to = to;
+  }
+
+  @JsonProperty(XdmContext.W3C_ACTIVITYSTREAMS_PREFIX + ":actor")
+  public Ac getActor() {
+    return actor;
+  }
+
+  public void setActor(Ac actor) {
+    this.actor = actor;
+  }
+
+  @JsonProperty(XdmContext.W3C_ACTIVITYSTREAMS_PREFIX + ":generator")
+  public Ge getGenerator() {
+    return generator;
+  }
+
+  public void setGenerator(Ge generator) {
+    this.generator = generator;
+  }
+
+  @JsonProperty(XdmContext.W3C_ACTIVITYSTREAMS_PREFIX + ":object")
+  public Ob getObject() {
+    return object;
+  }
+
+  public void setObject(Ob object) {
+    this.object = object;
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || !this.getClass().isAssignableFrom(o.getClass())) {
+      return false;
+    }
+
+    XdmEvent<?, ?, ?, ?> xdmEvent = (XdmEvent<?, ?, ?, ?>) o;
+
+    if (id != null ? !id.equals(xdmEvent.id) : xdmEvent.id != null) {
+      return false;
+    }
+    if (type != null ? !type.equals(xdmEvent.type) : xdmEvent.type != null) {
+      return false;
+    }
+    if (published != null ? !published.equals(xdmEvent.published) : xdmEvent.published != null) {
+      return false;
+    }
+    if (to != null ? !to.equals(xdmEvent.to) : xdmEvent.to != null) {
+      return false;
+    }
+    if (generator != null ? !generator.equals(xdmEvent.generator) : xdmEvent.generator != null) {
+      return false;
+    }
+    if (actor != null ? !actor.equals(xdmEvent.actor) : xdmEvent.actor != null) {
+      return false;
+    }
+    return object != null ? object.equals(xdmEvent.object) : xdmEvent.object == null;
+  }
+
+  @Override
+  public int hashCode() {
+    int result = id != null ? id.hashCode() : 0;
+    result = 31 * result + (type != null ? type.hashCode() : 0);
+    result = 31 * result + (published != null ? published.hashCode() : 0);
+    result = 31 * result + (to != null ? to.hashCode() : 0);
+    result = 31 * result + (generator != null ? generator.hashCode() : 0);
+    result = 31 * result + (actor != null ? actor.hashCode() : 0);
+    result = 31 * result + (object != null ? object.hashCode() : 0);
+    return result;
+  }
+
+  @Override
+  public String toString() {
+    return "XdmEvent{" +
+        "id='" + id + '\'' +
+        ", type='" + type + '\'' +
+        ", published='" + published + '\'' +
+        ", to=" + to +
+        ", generator=" + generator +
+        ", actor=" + actor +
+        ", object=" + object +
+        '}';
+  }
+}

--- a/events_xdm/src/main/java/com/adobe/xdm/content/ContentRepository.java
+++ b/events_xdm/src/main/java/com/adobe/xdm/content/ContentRepository.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright 2017 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+package com.adobe.xdm.content;
+
+import com.adobe.xdm.XdmObject;
+import com.adobe.xdm.common.XdmContext;
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonInclude.Include;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+
+@JsonInclude(Include.NON_NULL)
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class ContentRepository extends XdmObject {
+
+  protected String root;
+
+  public ContentRepository() {
+    super();
+    this.type = XdmContext.XDM_CONTENT_REPOSITORY_TYPE;
+  }
+
+  @JsonProperty(XdmContext.XDM_CONTENT_REPOSITORY_PREFIX + ":root")
+  public String getRoot() {
+    return root;
+  }
+
+  public void setRoot(String root) {
+    this.root = root;
+  }
+
+  @Override
+  public String toString() {
+    return "ContentRepository{" +
+        "id='" + id + '\'' +
+        ", type='" + type + '\'' +
+        ", root='" + root + '\'' +
+        '}';
+  }
+}

--- a/events_xdm/src/main/java/com/adobe/xdm/content/Page.java
+++ b/events_xdm/src/main/java/com/adobe/xdm/content/Page.java
@@ -1,0 +1,96 @@
+/*
+ * Copyright 2017 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+package com.adobe.xdm.content;
+
+import com.adobe.xdm.XdmObject;
+import com.adobe.xdm.common.XdmContext;
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonInclude.Include;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import java.util.Objects;
+
+@JsonInclude(Include.NON_NULL)
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class Page extends XdmObject {
+
+  private String title;
+  private String path;
+  private String version;
+
+  public Page() {
+    super();
+    this.type = XdmContext.XDM_COMPONENTIZED_PAGE_TYPE;
+  }
+
+  @JsonProperty(XdmContext.XDM_COMPONENTIZED_PAGE_PREFIX + ":title")
+  public String getTitle() {
+    return title;
+  }
+
+  public void setTitle(String title) {
+    this.title = title;
+  }
+
+  @JsonProperty(XdmContext.XDM_COMPONENTIZED_PAGE_PREFIX + ":path")
+  public String getPath() {
+    return path;
+  }
+
+  public void setPath(String pathname) {
+    this.path = pathname;
+  }
+
+  @JsonProperty(XdmContext.XDM_COMPONENTIZED_PAGE_PREFIX + ":version")
+  public String getVersion() {
+    return version;
+  }
+
+  public void setVersion(String version) {
+    this.version = version;
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    if (!super.equals(o)) {
+      return false;
+    }
+    Page page = (Page) o;
+    return Objects.equals(id, page.id) &&
+        Objects.equals(type, page.type) &&
+        Objects.equals(title, page.title) &&
+        Objects.equals(path, page.path) &&
+        Objects.equals(version, page.version);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(super.hashCode(), id, type, title, path, version);
+  }
+
+  @Override
+  public String toString() {
+    return "Page{" +
+        "title='" + title + '\'' +
+        ", path='" + path + '\'' +
+        ", version='" + version + '\'' +
+        ", id='" + id + '\'' +
+        ", type='" + type + '\'' +
+        '}';
+  }
+}

--- a/events_xdm/src/main/java/com/adobe/xdm/event/AemAssetCreatedEvent.java
+++ b/events_xdm/src/main/java/com/adobe/xdm/event/AemAssetCreatedEvent.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright 2017 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+package com.adobe.xdm.event;
+
+import com.adobe.xdm.common.XdmContext;
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonInclude.Include;
+
+@JsonInclude(Include.NON_NULL)
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class AemAssetCreatedEvent extends AemAssetEvent {
+
+  public AemAssetCreatedEvent() {
+    super();
+    this.type = XdmContext.XDM_EVENT_CREATED_TYPE;
+  }
+
+}

--- a/events_xdm/src/main/java/com/adobe/xdm/event/AemAssetDeletedEvent.java
+++ b/events_xdm/src/main/java/com/adobe/xdm/event/AemAssetDeletedEvent.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright 2017 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+package com.adobe.xdm.event;
+
+import com.adobe.xdm.common.XdmContext;
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonInclude.Include;
+
+
+@JsonInclude(Include.NON_NULL)
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class AemAssetDeletedEvent extends AemAssetEvent {
+
+  public AemAssetDeletedEvent() {
+    super();
+    this.type = XdmContext.XDM_EVENT_DELETED_TYPE;
+  }
+
+}

--- a/events_xdm/src/main/java/com/adobe/xdm/event/AemAssetEvent.java
+++ b/events_xdm/src/main/java/com/adobe/xdm/event/AemAssetEvent.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright 2017 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+package com.adobe.xdm.event;
+
+import com.adobe.xdm.assets.Asset;
+import com.adobe.xdm.common.XdmEvent;
+import com.adobe.xdm.content.ContentRepository;
+import com.adobe.xdm.extensions.aem.AemUser;
+import com.adobe.xdm.extensions.ims.ImsOrg;
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonInclude.Include;
+
+@JsonInclude(Include.NON_NULL)
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class AemAssetEvent extends XdmEvent<Asset, ImsOrg, ContentRepository, AemUser> {
+
+  public AemAssetEvent() {
+    super();
+    this.object = new Asset();
+  }
+
+}

--- a/events_xdm/src/main/java/com/adobe/xdm/event/AemAssetUpdatedEvent.java
+++ b/events_xdm/src/main/java/com/adobe/xdm/event/AemAssetUpdatedEvent.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright 2017 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+package com.adobe.xdm.event;
+
+import com.adobe.xdm.common.XdmContext;
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonInclude.Include;
+
+@JsonInclude(Include.NON_NULL)
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class AemAssetUpdatedEvent extends AemAssetEvent {
+
+  public AemAssetUpdatedEvent() {
+    super();
+    this.type = XdmContext.XDM_EVENT_UPDATED_TYPE;
+  }
+
+}

--- a/events_xdm/src/main/java/com/adobe/xdm/event/AemPageEvent.java
+++ b/events_xdm/src/main/java/com/adobe/xdm/event/AemPageEvent.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright 2017 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+package com.adobe.xdm.event;
+
+import com.adobe.xdm.common.XdmEvent;
+import com.adobe.xdm.content.ContentRepository;
+import com.adobe.xdm.content.Page;
+import com.adobe.xdm.extensions.aem.AemUser;
+import com.adobe.xdm.extensions.ims.ImsOrg;
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonInclude.Include;
+
+@JsonInclude(Include.NON_NULL)
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class AemPageEvent extends XdmEvent<Page, ImsOrg, ContentRepository, AemUser> {
+
+  public AemPageEvent() {
+    super();
+    this.object = new Page();
+  }
+}

--- a/events_xdm/src/main/java/com/adobe/xdm/event/AemPagePublishedEvent.java
+++ b/events_xdm/src/main/java/com/adobe/xdm/event/AemPagePublishedEvent.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright 2017 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+package com.adobe.xdm.event;
+
+import com.adobe.xdm.common.XdmContext;
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonInclude.Include;
+
+@JsonInclude(Include.NON_NULL)
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class AemPagePublishedEvent extends AemPageEvent {
+
+  public AemPagePublishedEvent() {
+    super();
+    this.type = XdmContext.XDM_EVENT_PUBLISHED_TYPE;
+  }
+
+}

--- a/events_xdm/src/main/java/com/adobe/xdm/event/AemPageUnpublishedEvent.java
+++ b/events_xdm/src/main/java/com/adobe/xdm/event/AemPageUnpublishedEvent.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright 2017 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+package com.adobe.xdm.event;
+
+import com.adobe.xdm.common.XdmContext;
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonInclude.Include;
+
+@JsonInclude(Include.NON_NULL)
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class AemPageUnpublishedEvent extends AemPageEvent {
+
+  public AemPageUnpublishedEvent() {
+    super();
+    this.type = XdmContext.XDM_EVENT_UNPUBLISHED_TYPE;
+  }
+
+}

--- a/events_xdm/src/main/java/com/adobe/xdm/event/CCAssetCreatedEvent.java
+++ b/events_xdm/src/main/java/com/adobe/xdm/event/CCAssetCreatedEvent.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright 2017 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+package com.adobe.xdm.event;
+
+import com.adobe.xdm.common.XdmContext;
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonInclude.Include;
+
+@JsonInclude(Include.NON_NULL)
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class CCAssetCreatedEvent extends CCAssetEvent {
+
+  public CCAssetCreatedEvent() {
+    super();
+    this.type = XdmContext.XDM_EVENT_CREATED_TYPE;
+  }
+
+}

--- a/events_xdm/src/main/java/com/adobe/xdm/event/CCAssetDeletedEvent.java
+++ b/events_xdm/src/main/java/com/adobe/xdm/event/CCAssetDeletedEvent.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright 2017 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+package com.adobe.xdm.event;
+
+import com.adobe.xdm.common.XdmContext;
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonInclude.Include;
+
+
+@JsonInclude(Include.NON_NULL)
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class CCAssetDeletedEvent extends CCAssetEvent {
+
+  public CCAssetDeletedEvent() {
+    super();
+    this.type = XdmContext.XDM_EVENT_DELETED_TYPE;
+  }
+
+}

--- a/events_xdm/src/main/java/com/adobe/xdm/event/CCAssetEvent.java
+++ b/events_xdm/src/main/java/com/adobe/xdm/event/CCAssetEvent.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright 2017 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+package com.adobe.xdm.event;
+
+import com.adobe.xdm.assets.Asset;
+import com.adobe.xdm.common.XdmEvent;
+import com.adobe.xdm.content.ContentRepository;
+import com.adobe.xdm.extensions.ims.ImsUser;
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonInclude.Include;
+
+@JsonInclude(Include.NON_NULL)
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class CCAssetEvent extends XdmEvent<Asset, ImsUser, ContentRepository, ImsUser> {
+
+  public CCAssetEvent() {
+    super();
+    this.object = new Asset();
+  }
+
+}

--- a/events_xdm/src/main/java/com/adobe/xdm/event/CCAssetUpdatedEvent.java
+++ b/events_xdm/src/main/java/com/adobe/xdm/event/CCAssetUpdatedEvent.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright 2017 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+package com.adobe.xdm.event;
+
+import com.adobe.xdm.common.XdmContext;
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonInclude.Include;
+
+@JsonInclude(Include.NON_NULL)
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class CCAssetUpdatedEvent extends CCAssetEvent {
+
+  public CCAssetUpdatedEvent() {
+    super();
+    this.type = XdmContext.XDM_EVENT_UPDATED_TYPE;
+  }
+
+}

--- a/events_xdm/src/main/java/com/adobe/xdm/event/CCDirectoryCreatedEvent.java
+++ b/events_xdm/src/main/java/com/adobe/xdm/event/CCDirectoryCreatedEvent.java
@@ -1,0 +1,22 @@
+/*
+ * Copyright 2017 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+package com.adobe.xdm.event;
+
+
+import com.adobe.xdm.common.XdmContext;
+
+public class CCDirectoryCreatedEvent extends CCDirectoryEvent {
+
+  public CCDirectoryCreatedEvent() {
+    this.type = XdmContext.XDM_EVENT_CREATED_TYPE;
+  }
+}

--- a/events_xdm/src/main/java/com/adobe/xdm/event/CCDirectoryEvent.java
+++ b/events_xdm/src/main/java/com/adobe/xdm/event/CCDirectoryEvent.java
@@ -1,0 +1,24 @@
+/*
+ * Copyright 2017 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+package com.adobe.xdm.event;
+
+import com.adobe.xdm.common.XdmEvent;
+import com.adobe.xdm.content.ContentRepository;
+import com.adobe.xdm.extensions.ims.ImsUser;
+import com.adobe.xdm.external.repo.Directory;
+
+public class CCDirectoryEvent extends XdmEvent<Directory, ImsUser, ContentRepository, ImsUser> {
+
+  public CCDirectoryEvent() {
+    this.object = new Directory();
+  }
+}

--- a/events_xdm/src/main/java/com/adobe/xdm/event/OsgiEmittedEvent.java
+++ b/events_xdm/src/main/java/com/adobe/xdm/event/OsgiEmittedEvent.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2017 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+package com.adobe.xdm.event;
+
+import com.adobe.xdm.common.XdmContext;
+import com.adobe.xdm.common.XdmEvent;
+import com.adobe.xdm.content.ContentRepository;
+import com.adobe.xdm.extensions.aem.AemUser;
+import com.adobe.xdm.extensions.aem.OsgiEvent;
+import com.adobe.xdm.extensions.ims.ImsOrg;
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonInclude.Include;
+
+@JsonInclude(Include.NON_NULL)
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class OsgiEmittedEvent extends
+    XdmEvent<OsgiEvent, ImsOrg, ContentRepository, AemUser> {
+
+  public OsgiEmittedEvent() {
+    super();
+    this.object = new OsgiEvent();
+    this.type = XdmContext.XDM_EVENT_EMITTED_TYPE;
+  }
+
+
+}

--- a/events_xdm/src/main/java/com/adobe/xdm/extensions/aem/AemUser.java
+++ b/events_xdm/src/main/java/com/adobe/xdm/extensions/aem/AemUser.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright 2017 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+package com.adobe.xdm.extensions.aem;
+
+import com.adobe.xdm.XdmObject;
+import com.adobe.xdm.common.XdmContext;
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonInclude.Include;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+@JsonInclude(Include.NON_NULL)
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class AemUser extends XdmObject {
+
+  private String aemUserId;
+
+  public AemUser() {
+    super();
+    this.type = XdmContext.XDM_AEM_USER_TYPE;
+  }
+
+  @JsonProperty(XdmContext.XDM_AEM_USER_PREFIX + ":id")
+  public String getAemUserId() {
+    return this.aemUserId;
+  }
+
+  public void setAemUserId(String aemUserId) {
+    this.aemUserId = aemUserId;
+  }
+
+  @Override
+  public String toString() {
+    return "AemUser{" +
+        "id='" + id + '\'' +
+        ", type='" + type + '\'' +
+        ", aemUserId='" + aemUserId + '\'' +
+        '}';
+  }
+}

--- a/events_xdm/src/main/java/com/adobe/xdm/extensions/aem/OsgiEvent.java
+++ b/events_xdm/src/main/java/com/adobe/xdm/extensions/aem/OsgiEvent.java
@@ -1,0 +1,90 @@
+/*
+ * Copyright 2017 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+package com.adobe.xdm.extensions.aem;
+
+import com.adobe.xdm.XdmObject;
+import com.adobe.xdm.common.XdmContext;
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonInclude.Include;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import java.util.Hashtable;
+
+@JsonInclude(Include.NON_NULL)
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class OsgiEvent extends XdmObject {
+
+  String topic;
+  Hashtable properties;
+
+  public OsgiEvent() {
+    super();
+    this.type = XdmContext.OSGI_EVENT_TYPE;
+  }
+
+  @JsonProperty(XdmContext.OSGI_EVENT_PREFIX + ":topic")
+  public String getTopic() {
+    return topic;
+  }
+
+  public void setTopic(String topic) {
+    this.topic = topic;
+    this.type =  XdmContext.OSGI_EVENT_TYPE +":"+topic;
+  }
+
+  @JsonProperty(XdmContext.OSGI_EVENT_PREFIX + ":properties")
+  public Hashtable getProperties() {
+    return properties;
+  }
+
+  public void setProperties(Hashtable properties) {
+    this.properties = properties;
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    if (!super.equals(o)) {
+      return false;
+    }
+
+    OsgiEvent that = (OsgiEvent) o;
+
+    if (topic != null ? !topic.equals(that.topic) : that.topic != null) {
+      return false;
+    }
+    return properties != null ? properties.equals(that.properties) : that.properties == null;
+  }
+
+  @Override
+  public int hashCode() {
+    int result = super.hashCode();
+    result = 31 * result + (topic != null ? topic.hashCode() : 0);
+    result = 31 * result + (properties != null ? properties.hashCode() : 0);
+    return result;
+  }
+
+  @Override
+  public String toString() {
+    return "OsgiEvent{" +
+        "id='" + id + '\'' +
+        ", type='" + type + '\'' +
+        ", topic='" + topic + '\'' +
+        ", properties=" + properties +
+        '}';
+  }
+}

--- a/events_xdm/src/main/java/com/adobe/xdm/extensions/ims/ImsOrg.java
+++ b/events_xdm/src/main/java/com/adobe/xdm/extensions/ims/ImsOrg.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright 2017 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+package com.adobe.xdm.extensions.ims;
+
+import com.adobe.xdm.XdmObject;
+import com.adobe.xdm.common.XdmContext;
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonInclude.Include;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+@JsonInclude(Include.NON_NULL)
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class ImsOrg extends XdmObject {
+
+  private String imsOrgId;
+
+  public ImsOrg() {
+    super();
+    this.type = XdmContext.XDM_IMS_ORG_TYPE;
+  }
+
+  @JsonProperty(XdmContext.XDM_IMS_ORG_PREFIX + ":id")
+  public String getImsOrgId() {
+    return imsOrgId;
+  }
+
+
+  public void setImsOrgId(String imsOrgId) {
+    this.imsOrgId = imsOrgId;
+  }
+
+  @Override
+  public String toString() {
+    return "ImsOrg{" +
+        "id='" + id + '\'' +
+        ", type='" + type + '\'' +
+        ", imsOrgId='" + imsOrgId + '\'' +
+        '}';
+  }
+}

--- a/events_xdm/src/main/java/com/adobe/xdm/extensions/ims/ImsUser.java
+++ b/events_xdm/src/main/java/com/adobe/xdm/extensions/ims/ImsUser.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright 2017 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+package com.adobe.xdm.extensions.ims;
+
+import com.adobe.xdm.XdmObject;
+import com.adobe.xdm.common.XdmContext;
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonInclude.Include;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+@JsonInclude(Include.NON_NULL)
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class ImsUser extends XdmObject {
+
+  private String imsUserId;
+
+  public ImsUser() {
+    super();
+    this.type = XdmContext.XDM_IMS_USER_TYPE;
+  }
+
+  @JsonProperty(XdmContext.XDM_IMS_USER_PREFIX + ":id")
+  public String getImsUserId() {
+    return this.imsUserId;
+  }
+
+  public void setImsUserId(String imsUserId) {
+    this.imsUserId = imsUserId;
+  }
+
+  @Override
+  public String toString() {
+    return "ImsUser{" +
+        "id='" + id + '\'' +
+        ", type='" + type + '\'' +
+        ", imsUserId='" + imsUserId + '\'' +
+        '}';
+  }
+}

--- a/events_xdm/src/main/java/com/adobe/xdm/external/repo/Directory.java
+++ b/events_xdm/src/main/java/com/adobe/xdm/external/repo/Directory.java
@@ -1,0 +1,129 @@
+/*
+ * Copyright 2017 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+package com.adobe.xdm.external.repo;
+
+import static com.adobe.xdm.common.XdmContext.XDM_DIRECTORY_PREFIX;
+import static com.adobe.xdm.common.XdmContext.XDM_DIRECTORY_TYPE;
+
+import com.adobe.xdm.XdmObject;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+public class Directory extends XdmObject {
+
+  private String assetId;
+  private String name;
+  private String path;
+  private String etag;
+  private String format;
+
+  public Directory() {
+    this.type = XDM_DIRECTORY_TYPE;
+  }
+
+  @JsonProperty(XDM_DIRECTORY_PREFIX + ":asset_id")
+  public String getAssetId() {
+    return assetId;
+  }
+
+  public void setAssetId(String assetId) {
+    this.assetId = assetId;
+  }
+
+  @JsonProperty(XDM_DIRECTORY_PREFIX + ":name")
+  public String getName() {
+    return name;
+  }
+
+  public void setName(String name) {
+    this.name = name;
+  }
+
+  @JsonProperty(XDM_DIRECTORY_PREFIX + ":path")
+  public String getPath() {
+    return path;
+  }
+
+  public void setPath(String path) {
+    this.path = path;
+  }
+
+  @JsonProperty(XDM_DIRECTORY_PREFIX + ":etag")
+  public String getEtag() {
+    return etag;
+  }
+
+  public void setEtag(String etag) {
+    this.etag = etag;
+  }
+
+  @JsonProperty(XDM_DIRECTORY_PREFIX + ":format")
+  public String getFormat() {
+    return format;
+  }
+
+  public void setFormat(String format) {
+    this.format = format;
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    if (!super.equals(o)) {
+      return false;
+    }
+
+    Directory directory = (Directory) o;
+
+    if (assetId != null ? !assetId.equals(directory.assetId) : directory.assetId != null) {
+      return false;
+    }
+    if (name != null ? !name.equals(directory.name) : directory.name != null) {
+      return false;
+    }
+    if (path != null ? !path.equals(directory.path) : directory.path != null) {
+      return false;
+    }
+    if (etag != null ? !etag.equals(directory.etag) : directory.etag != null) {
+      return false;
+    }
+    return format != null ? format.equals(directory.format) : directory.format == null;
+  }
+
+  @Override
+  public int hashCode() {
+    int result = super.hashCode();
+    result = 31 * result + (assetId != null ? assetId.hashCode() : 0);
+    result = 31 * result + (name != null ? name.hashCode() : 0);
+    result = 31 * result + (path != null ? path.hashCode() : 0);
+    result = 31 * result + (etag != null ? etag.hashCode() : 0);
+    result = 31 * result + (format != null ? format.hashCode() : 0);
+    return result;
+  }
+
+  @Override
+  public String toString() {
+    return "Directory{" +
+        "assetId='" + assetId + '\'' +
+        ", name='" + name + '\'' +
+        ", path='" + path + '\'' +
+        ", etag='" + etag + '\'' +
+        ", format='" + format + '\'' +
+        ", id='" + id + '\'' +
+        ", type='" + type + '\'' +
+        '}';
+  }
+}

--- a/events_xdm/src/main/json-ld/activitystreams.jsonld
+++ b/events_xdm/src/main/json-ld/activitystreams.jsonld
@@ -1,0 +1,364 @@
+{
+  "@context": {
+    "@vocab": "_:",
+    "xsd": "http://www.w3.org/2001/XMLSchema#",
+    "as": "https://www.w3.org/ns/activitystreams#",
+    "ldp": "http://www.w3.org/ns/ldp#",
+    "id": "@id",
+    "type": "@type",
+    "Accept": "as:Accept",
+    "Activity": "as:Activity",
+    "IntransitiveActivity": "as:IntransitiveActivity",
+    "Add": "as:Add",
+    "Announce": "as:Announce",
+    "Application": "as:Application",
+    "Arrive": "as:Arrive",
+    "Article": "as:Article",
+    "Audio": "as:Audio",
+    "Block": "as:Block",
+    "Collection": "as:Collection",
+    "CollectionPage": "as:CollectionPage",
+    "Relationship": "as:Relationship",
+    "Create": "as:Create",
+    "Delete": "as:Delete",
+    "Dislike": "as:Dislike",
+    "Document": "as:Document",
+    "Event": "as:Event",
+    "Follow": "as:Follow",
+    "Flag": "as:Flag",
+    "Group": "as:Group",
+    "Ignore": "as:Ignore",
+    "Image": "as:Image",
+    "Invite": "as:Invite",
+    "Join": "as:Join",
+    "Leave": "as:Leave",
+    "Like": "as:Like",
+    "Link": "as:Link",
+    "Mention": "as:Mention",
+    "Note": "as:Note",
+    "Object": "as:Object",
+    "Offer": "as:Offer",
+    "OrderedCollection": "as:OrderedCollection",
+    "OrderedCollectionPage": "as:OrderedCollectionPage",
+    "Organization": "as:Organization",
+    "Page": "as:Page",
+    "Person": "as:Person",
+    "Place": "as:Place",
+    "Profile": "as:Profile",
+    "Question": "as:Question",
+    "Reject": "as:Reject",
+    "Remove": "as:Remove",
+    "Service": "as:Service",
+    "TentativeAccept": "as:TentativeAccept",
+    "TentativeReject": "as:TentativeReject",
+    "Tombstone": "as:Tombstone",
+    "Undo": "as:Undo",
+    "Update": "as:Update",
+    "Video": "as:Video",
+    "View": "as:View",
+    "Listen": "as:Listen",
+    "Read": "as:Read",
+    "Move": "as:Move",
+    "Travel": "as:Travel",
+    "IsFollowing": "as:IsFollowing",
+    "IsFollowedBy": "as:IsFollowedBy",
+    "IsContact": "as:IsContact",
+    "IsMember": "as:IsMember",
+    "subject": {
+      "@id": "as:subject",
+      "@type": "@id"
+    },
+    "relationship": {
+      "@id": "as:relationship",
+      "@type": "@id"
+    },
+    "actor": {
+      "@id": "as:actor",
+      "@type": "@id"
+    },
+    "attributedTo": {
+      "@id": "as:attributedTo",
+      "@type": "@id"
+    },
+    "attachment": {
+      "@id": "as:attachment",
+      "@type": "@id"
+    },
+    "attachments": {
+      "@id": "as:attachments",
+      "@type": "@id"
+    },
+    "author": {
+      "@id": "as:author",
+      "@type": "@id"
+    },
+    "bcc": {
+      "@id": "as:bcc",
+      "@type": "@id"
+    },
+    "bto": {
+      "@id": "as:bto",
+      "@type": "@id"
+    },
+    "cc": {
+      "@id": "as:cc",
+      "@type": "@id"
+    },
+    "context": {
+      "@id": "as:context",
+      "@type": "@id"
+    },
+    "current": {
+      "@id": "as:current",
+      "@type": "@id"
+    },
+    "first": {
+      "@id": "as:first",
+      "@type": "@id"
+    },
+    "generator": {
+      "@id": "as:generator",
+      "@type": "@id"
+    },
+    "icon": {
+      "@id": "as:icon",
+      "@type": "@id"
+    },
+    "image": {
+      "@id": "as:image",
+      "@type": "@id"
+    },
+    "inReplyTo": {
+      "@id": "as:inReplyTo",
+      "@type": "@id"
+    },
+    "items": {
+      "@id": "as:items",
+      "@type": "@id"
+    },
+    "instrument": {
+      "@id": "as:instrument",
+      "@type": "@id"
+    },
+    "orderedItems": {
+      "@id": "as:items",
+      "@type": "@id",
+      "@container": "@list"
+    },
+    "last": {
+      "@id": "as:last",
+      "@type": "@id"
+    },
+    "location": {
+      "@id": "as:location",
+      "@type": "@id"
+    },
+    "next": {
+      "@id": "as:next",
+      "@type": "@id"
+    },
+    "object": {
+      "@id": "as:object",
+      "@type": "@id"
+    },
+    "oneOf": {
+      "@id": "as:oneOf",
+      "@type": "@id"
+    },
+    "anyOf": {
+      "@id": "as:anyOf",
+      "@type": "@id"
+    },
+    "closed": {
+      "@id": "as:closed",
+      "@type": "xsd:dateTime"
+    },
+    "origin": {
+      "@id": "as:origin",
+      "@type": "@id"
+    },
+    "accuracy": {
+      "@id": "as:accuracy",
+      "@type": "xsd:float"
+    },
+    "prev": {
+      "@id": "as:prev",
+      "@type": "@id"
+    },
+    "preview": {
+      "@id": "as:preview",
+      "@type": "@id"
+    },
+    "provider": {
+      "@id": "as:provider",
+      "@type": "@id"
+    },
+    "replies": {
+      "@id": "as:replies",
+      "@type": "@id"
+    },
+    "result": {
+      "@id": "as:result",
+      "@type": "@id"
+    },
+    "audience": {
+      "@id": "as:audience",
+      "@type": "@id"
+    },
+    "partOf": {
+      "@id": "as:partOf",
+      "@type": "@id"
+    },
+    "tag": {
+      "@id": "as:tag",
+      "@type": "@id"
+    },
+    "tags": {
+      "@id": "as:tag",
+      "@type": "@id"
+    },
+    "target": {
+      "@id": "as:target",
+      "@type": "@id"
+    },
+    "to": {
+      "@id": "as:to",
+      "@type": "@id"
+    },
+    "url": {
+      "@id": "as:url",
+      "@type": "@id"
+    },
+    "altitude": {
+      "@id": "as:altitude",
+      "@type": "xsd:float"
+    },
+    "content": "as:content",
+    "contentMap": {
+      "@id": "as:content",
+      "@container": "@language"
+    },
+    "name": "as:name",
+    "nameMap": {
+      "@id": "as:name",
+      "@container": "@language"
+    },
+    "downstreamDuplicates": "as:downStreamDuplicates",
+    "duration": {
+      "@id": "as:duration",
+      "@type": "xsd:duration"
+    },
+    "endTime": {
+      "@id": "as:endTime",
+      "@type": "xsd:dateTime"
+    },
+    "height": {
+      "@id": "as:height",
+      "@type": "xsd:nonNegativeInteger"
+    },
+    "href": {
+      "@id": "as:href",
+      "@type": "@id"
+    },
+    "hreflang": "as:hreflang",
+    "latitude": {
+      "@id": "as:latitude",
+      "@type": "xsd:float"
+    },
+    "longitude": {
+      "@id": "as:longitude",
+      "@type": "xsd:float"
+    },
+    "mediaType": "as:mediaType",
+    "published": {
+      "@id": "as:published",
+      "@type": "xsd:dateTime"
+    },
+    "radius": {
+      "@id": "as:radius",
+      "@type": "xsd:float"
+    },
+    "rating": {
+      "@id": "as:rating",
+      "@type": "xsd:float"
+    },
+    "rel": "as:rel",
+    "startIndex": {
+      "@id": "as:startIndex",
+      "@type": "xsd:nonNegativeInteger"
+    },
+    "startTime": {
+      "@id": "as:startTime",
+      "@type": "xsd:dateTime"
+    },
+    "summary": "as:summary",
+    "summaryMap": {
+      "@id": "as:summary",
+      "@container": "@language"
+    },
+    "totalItems": {
+      "@id": "as:totalItems",
+      "@type": "xsd:nonNegativeInteger"
+    },
+    "units": "as:units",
+    "updated": {
+      "@id": "as:updated",
+      "@type": "xsd:dateTime"
+    },
+    "upstreamDuplicates": "as:upstreamDuplicates",
+    "verb": "as:verb",
+    "width": {
+      "@id": "as:width",
+      "@type": "xsd:nonNegativeInteger"
+    },
+    "describes": {
+      "@id": "as:describes",
+      "@type": "@id"
+    },
+    "formerType": {
+      "@id": "as:formerType",
+      "@type": "@id"
+    },
+    "deleted": {
+      "@id": "as:deleted",
+      "@type": "xsd:dateTime"
+    },
+    "inbox": {
+      "@id": "ldp:inbox",
+      "@type": "@id"
+    },
+    "outbox": {
+      "@id": "as:outbox",
+      "@type": "@id"
+    },
+    "following": {
+      "@id": "as:following",
+      "@type": "@id"
+    },
+    "followers": {
+      "@id": "as:followers",
+      "@type": "@id"
+    },
+    "streams": {
+      "@id": "as:streams",
+      "@type": "@id"
+    },
+    "preferredUsername": "as:preferredUsername",
+    "endpoints": {
+      "@id": "as:endpoints",
+      "@type": "@id"
+    },
+    "uploadMedia": {
+      "@id": "as:uploadMedia",
+      "@type": "@id"
+    },
+    "proxyUrl": {
+      "@id": "as:proxyUrl",
+      "@type": "@id"
+    },
+    "oauthClientAuthorize": "as:oauthClientAuthorize",
+    "provideClientKey": "as:provideClientKey",
+    "authorizeClientKey": "as:authorizeClientKey",
+    "source": "as:source"
+  }
+}

--- a/events_xdm/src/test/java/com/adobe/xdm/event/JsonUtils.java
+++ b/events_xdm/src/test/java/com/adobe/xdm/event/JsonUtils.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright 2017 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+package com.adobe.xdm.event;
+
+import com.fasterxml.jackson.core.JsonFactory;
+import com.fasterxml.jackson.core.JsonGenerator;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.io.IOException;
+import java.io.StringWriter;
+import java.io.Writer;
+
+public class JsonUtils {
+
+  private static final ObjectMapper JSON_MAPPER = new ObjectMapper();
+  private static final JsonFactory JSON_FACTORY = new JsonFactory(JSON_MAPPER);
+
+  public static String toPrettyString(Object jsonObject) throws IOException {
+    final StringWriter sw = new StringWriter();
+    writePrettyPrint(sw, jsonObject);
+    return sw.toString();
+  }
+
+  public static void writePrettyPrint(Writer writer, Object jsonObject) throws IOException {
+    final JsonGenerator jw = JSON_FACTORY.createGenerator(writer);
+    jw.useDefaultPrettyPrinter();
+    jw.writeObject(jsonObject);
+  }
+
+
+}

--- a/events_xdm/src/test/java/com/adobe/xdm/event/SerializationTest.java
+++ b/events_xdm/src/test/java/com/adobe/xdm/event/SerializationTest.java
@@ -1,0 +1,279 @@
+/*
+ * Copyright 2017 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+package com.adobe.xdm.event;
+
+import static org.junit.Assert.assertTrue;
+
+import com.adobe.xdm.Xdm;
+import com.adobe.xdm.assets.Asset;
+import com.adobe.xdm.content.ContentRepository;
+import com.adobe.xdm.content.Page;
+import com.adobe.xdm.extensions.aem.AemUser;
+import com.adobe.xdm.extensions.aem.OsgiEvent;
+import com.adobe.xdm.extensions.ims.ImsOrg;
+import com.adobe.xdm.extensions.ims.ImsUser;
+import com.adobe.xdm.external.repo.Directory;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Paths;
+import java.util.Hashtable;
+import org.junit.Before;
+import org.junit.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class SerializationTest {
+
+  Logger logger = LoggerFactory.getLogger(SerializationTest.class);
+  private static final String PUBLISHED_DATE = "1970-01-01T01:00:00.000+01";
+  //the above is new SimpleDateFormat(XdmContext.DATE_FORMAT,Locale.US).format(new Date(0));
+  private ObjectMapper mapper;
+
+  @Before
+  public void setUp() {
+    mapper = new ObjectMapper();
+  }
+
+  private CCAssetEvent getCCAssetSampleEvent(CCAssetEvent assetEvent) {
+    assetEvent.setId("82235bac-2b81-4e70-90b5-2bd1f04b5c7b");
+    assetEvent.setPublished(PUBLISHED_DATE);
+    ImsUser imsUser = new ImsUser();
+    imsUser.setImsUserId("D13A1E7053E46A220A4C86E1@AdobeID");
+    assetEvent.setTo(imsUser);
+    assetEvent.setActor(imsUser);
+
+    ContentRepository creativeCloud = new ContentRepository();
+    creativeCloud.setRoot("https://cc-api-storage.adobe.io/");
+    assetEvent.setGenerator(creativeCloud);
+
+    Asset asset = new Asset();
+    asset.setFormat("image/jpeg");
+    asset.setAssetId("urn:aaid:sc:us:4123ba4c-93a8-4c5d-b979-ffbbe4318185");
+    asset.setAssetName("example.jpg");
+    asset.setEtag("6fc55d0389d856ae7deccebba54f110e");
+    asset.setPath("/MyFolder/example.jpg");
+    assetEvent.setObject(asset);
+    return assetEvent;
+  }
+
+  private CCDirectoryEvent getCCDirectorySampleEvent(CCDirectoryEvent directoryEvent) {
+    directoryEvent.setId("82235bac-2b81-4e70-90b5-2bd1f04b5c7b");
+    directoryEvent.setPublished(PUBLISHED_DATE);
+    ImsUser imsUser = new ImsUser();
+    imsUser.setImsUserId("D13A1E7053E46A220A4C86E1@AdobeID");
+    directoryEvent.setTo(imsUser);
+    directoryEvent.setActor(imsUser);
+
+    ContentRepository creativeCloud = new ContentRepository();
+    creativeCloud.setRoot("https://cc-api-storage.adobe.io/");
+    directoryEvent.setGenerator(creativeCloud);
+
+    Directory directory = new Directory();
+    directory.setFormat("application/vnd.adobecloud.directory+json");
+    directory.setAssetId("urn:aaid:sc:us:4123ba4c-93a8-4c5d-b979-ffbbe4318185");
+    directory.setName("example");
+    directory.setEtag("6fc55d0389d856ae7deccebba54f110e");
+    directory.setPath("/MyFolder/example");
+    directoryEvent.setObject(directory);
+    return directoryEvent;
+  }
+
+  private <T> void assertDeserialization(T xdmEvent, String xdmEventJsonFile,
+      Class<T> xdmEventClass)
+      throws IOException {
+    T xdmEventFromFile = mapper.readValue(readFile(xdmEventJsonFile), xdmEventClass);
+    assertTrue(xdmEventFromFile.equals(xdmEvent));
+  }
+
+  @Test
+  public void testCCAssetCreatedEventSerialization() throws IOException {
+    CCAssetEvent xdmEvent = getCCAssetSampleEvent(new CCAssetCreatedEvent());
+    String prettyString = JsonUtils.toPrettyString(xdmEvent);
+    logger.info(prettyString);
+    assertDeserialization(xdmEvent, "asset_created_cc_sample.json", CCAssetEvent.class);
+  }
+
+  @Test
+  public void testCCAssetUpdatedEventSerialization() throws IOException {
+    CCAssetEvent xdmEvent = getCCAssetSampleEvent(new CCAssetUpdatedEvent());
+    String prettyString = JsonUtils.toPrettyString(xdmEvent);
+    logger.info(prettyString);
+
+    assertDeserialization(xdmEvent, "asset_updated_cc_sample.json", CCAssetEvent.class);
+  }
+
+  @Test
+  public void testCCAssetDeletedEventSerialization() throws IOException {
+    CCAssetEvent assetEvent = getCCAssetSampleEvent(new CCAssetDeletedEvent());
+    Asset asset = new Asset();
+    asset.setAssetId("urn:aaid:sc:us:4123ba4c-93a8-4c5d-b979-ffbbe4318185");
+    assetEvent.setObject(asset);
+    String prettyString = JsonUtils.toPrettyString(assetEvent);
+    logger.info(prettyString);
+
+    assertDeserialization(assetEvent, "asset_deleted_cc_sample.json", CCAssetEvent.class);
+  }
+
+  @Test
+  public void testCCDirectoryCreatedEventSerialization() throws IOException {
+    CCDirectoryEvent xdmEvent = getCCDirectorySampleEvent(new CCDirectoryCreatedEvent());
+    String prettyString = JsonUtils.toPrettyString(xdmEvent);
+    logger.info(prettyString);
+    assertDeserialization(xdmEvent, "directory_created_cc_sample.json", CCDirectoryEvent.class);
+  }
+
+  private AemAssetEvent getAemAssetSampleEvent(AemAssetEvent assetEvent) {
+    assetEvent.setId("82235bac-2b81-4e70-90b5-2bd1f04b5c7b");
+    assetEvent.setPublished(PUBLISHED_DATE);
+    ImsOrg imsOrg = new ImsOrg();
+    imsOrg.setImsOrgId("08B3E5CE5822FC520A494229@AdobeOrg");
+    assetEvent.setTo(imsOrg);
+
+    ContentRepository aemInstance = new ContentRepository();
+    aemInstance.setRoot("http://francois.corp.adobe.com:4502/");
+    assetEvent.setGenerator(aemInstance);
+
+    AemUser aemUser = new AemUser();
+    aemUser.setAemUserId("admin");
+    assetEvent.setActor(aemUser);
+
+    Asset asset = new Asset();
+    asset.setFormat("image/png");
+    asset.setAssetId("urn:aaid:aem:4123ba4c-93a8-4c5d-b979-ffbbe4318185");
+    asset.setAssetName("Fx_DUKE-small.png");
+    asset.setEtag("6fc55d0389d856ae7deccebba54f110e");
+    asset.setPath("/content/dam/Fx_DUKE-small.png");
+    assetEvent.setObject(asset);
+    return assetEvent;
+  }
+
+
+  @Test
+  public void testAemAssetCreatedEventSerialization() throws IOException {
+    AemAssetEvent xdmEvent = getAemAssetSampleEvent(new AemAssetCreatedEvent());
+    String prettyString = JsonUtils.toPrettyString(xdmEvent);
+    logger.info(prettyString);
+    assertDeserialization(xdmEvent, "asset_created_aem_sample.json", AemAssetEvent.class);
+  }
+
+  @Test
+  public void testAemAssetUpdatedEventSerialization() throws IOException {
+    AemAssetEvent xdmEvent = getAemAssetSampleEvent(new AemAssetUpdatedEvent());
+    String prettyString = JsonUtils.toPrettyString(xdmEvent);
+    logger.info(prettyString);
+    assertDeserialization(xdmEvent, "asset_updated_aem_sample.json", AemAssetEvent.class);
+  }
+
+  @Test
+  public void testAemAssetDeletedEventSerialization() throws IOException {
+    AemAssetEvent assetEvent = getAemAssetSampleEvent(new AemAssetDeletedEvent());
+    Asset asset = new Asset();
+    asset.setAssetId("urn:aaid:aem:4123ba4c-93a8-4c5d-b979-ffbbe4318185");
+    assetEvent.setObject(asset);
+    String prettyString = JsonUtils.toPrettyString(assetEvent);
+    logger.info(prettyString);
+
+    assertDeserialization(assetEvent, "asset_deleted_aem_sample.json", AemAssetEvent.class);
+  }
+
+
+  private AemPageEvent getAemPageSampleEvent(AemPageEvent pageEvent) {
+    pageEvent.setId("82235bac-2b81-4e70-90b5-2bd1f04b5c7b");
+    pageEvent.setPublished(PUBLISHED_DATE);
+
+    ImsOrg imsOrg = new ImsOrg();
+    imsOrg.setImsOrgId("08B3E5CE5822FC520A494229@AdobeOrg");
+    pageEvent.setTo(imsOrg);
+
+    ContentRepository aemInstance = new ContentRepository();
+    aemInstance.setRoot("http://francois.corp.adobe.com:4502/");
+    pageEvent.setGenerator(aemInstance);
+
+    AemUser aemUser = new AemUser();
+    aemUser.setAemUserId("admin");
+    pageEvent.setActor(aemUser);
+
+    Page page = new Page();
+    page.setTitle("Vintage Collection");
+    page.setPath("/content/geometrixx/en/vintage.html");
+    page.setId("http://adobesummit.adobesandbox.com:4502/content/geometrixx/en/vintage.html");
+    pageEvent.setObject(page);
+    return pageEvent;
+  }
+
+  @Test
+  public void testAemPagePublishedEventSerialization() throws IOException {
+    AemPageEvent xdmEvent = getAemPageSampleEvent(new AemPagePublishedEvent());
+    String prettyString = JsonUtils.toPrettyString(xdmEvent);
+    logger.info(prettyString);
+
+    assertDeserialization(xdmEvent, "page_published_aem_sample.json", AemPageEvent.class);
+  }
+
+  @Test
+  public void testAemPageUnpublishedEventSerialization() throws IOException {
+    AemPageEvent xdmEvent = getAemPageSampleEvent(new AemPageUnpublishedEvent());
+    String prettyString = JsonUtils.toPrettyString(xdmEvent);
+    logger.info(prettyString);
+
+    assertDeserialization(xdmEvent, "page_unpublished_aem_sample.json", AemPageEvent.class);
+  }
+
+  private OsgiEmittedEvent getOsgiEmittedEventSampleEvent() {
+    OsgiEmittedEvent osgiEmittedEvent = new OsgiEmittedEvent();
+
+    osgiEmittedEvent.setId("82235bac-2b81-4e70-90b5-2bd1f04b5c7b");
+    osgiEmittedEvent.setPublished(PUBLISHED_DATE);
+    ImsOrg imsOrg = new ImsOrg();
+    imsOrg.setImsOrgId("08B3E5CE5822FC520A494229@AdobeOrg");
+    osgiEmittedEvent.setTo(imsOrg);
+
+    ContentRepository aemInstance = new ContentRepository();
+    aemInstance.setRoot("http://francois.corp.adobe.com:4502/");
+    osgiEmittedEvent.setGenerator(aemInstance);
+
+    Hashtable properties = new Hashtable();
+    properties.put("type", "created");
+    properties.put("id", "1234");
+    OsgiEvent osgiEvent = new OsgiEvent();
+    osgiEvent.setTopic("io/adobe/event/sample/sku");
+    osgiEvent.setProperties(properties);
+
+    osgiEmittedEvent.setObject(osgiEvent);
+    return osgiEmittedEvent;
+  }
+
+  @Test
+  public void testOsgiEmittedEventSampleEventSerialization() throws IOException {
+    OsgiEmittedEvent xdmEvent = getOsgiEmittedEventSampleEvent();
+    String prettyString = JsonUtils.toPrettyString(xdmEvent);
+    logger.info(prettyString);
+    assertDeserialization(xdmEvent, "custom_osgi_emitted_aem_sample.json", OsgiEmittedEvent.class);
+  }
+
+  @Test
+  public void testXdmContextSerialization() throws IOException {
+    Xdm xdm = new Xdm();
+    String prettyString = JsonUtils.toPrettyString(xdm);
+    logger.info(prettyString);
+  }
+
+  private static String readFile(String fileName) throws IOException {
+    byte[] encoded = Files.readAllBytes(Paths.get(
+        Thread.currentThread().getContextClassLoader()
+            .getResource(fileName).getPath()));
+    return new String(encoded, StandardCharsets.UTF_8);
+  }
+
+}

--- a/events_xdm/src/test/resources/asset_created_aem_sample.json
+++ b/events_xdm/src/test/resources/asset_created_aem_sample.json
@@ -1,0 +1,38 @@
+{
+  "@id": "82235bac-2b81-4e70-90b5-2bd1f04b5c7b",
+  "@type": "xdmCreated",
+  "xdmEventEnvelope:objectType": "xdmAsset",
+  "activitystreams:published": "1970-01-01T01:00:00.000+01",
+  "activitystreams:to": {
+    "xdmImsOrg:id": "08B3E5CE5822FC520A494229@AdobeOrg",
+    "@type": "xdmImsOrg"
+  },
+  "activitystreams:generator": {
+    "xdmContentRepository:root": "http://francois.corp.adobe.com:4502/",
+    "@type": "xdmContentRepository"
+  },
+  "activitystreams:actor": {
+    "xdmAemUser:id": "admin",
+    "@type": "xdmAemUser"
+  },
+  "activitystreams:object": {
+    "@type": "xdmAsset",
+    "xdmAsset:asset_id": "urn:aaid:aem:4123ba4c-93a8-4c5d-b979-ffbbe4318185",
+    "xdmAsset:asset_name": "Fx_DUKE-small.png",
+    "xdmAsset:etag": "6fc55d0389d856ae7deccebba54f110e",
+    "xdmAsset:path": "/content/dam/Fx_DUKE-small.png",
+    "xdmAsset:format": "image/png"
+  },
+  "@context": {
+    "activitystreams": "http://www.w3.org/ns/activitystreams#",
+    "xdmEventEnvelope": "https://ns.adobe.com/xdm/common/eventenvelope#",
+    "xdmAsset": "http://ns.adobe.com/xdm/assets/asset#",
+    "xdmImsOrg": "https://ns.adobe.com/xdm/ims/organization#",
+    "xdmContentRepository": "https://ns.adobe.com/xdm/content/repository",
+    "xdmAemUser": "https://ns.adobe.com/xdm/aem/user#",
+    "xdmCreated": "https://ns.adobe.com/xdm/common/event/created#"
+  }
+}
+
+
+

--- a/events_xdm/src/test/resources/asset_created_cc_sample.json
+++ b/events_xdm/src/test/resources/asset_created_cc_sample.json
@@ -1,0 +1,34 @@
+{
+  "@id": "82235bac-2b81-4e70-90b5-2bd1f04b5c7b",
+  "@type": "xdmCreated",
+  "xdmEventEnvelope:objectType": "xdmAsset",
+  "activitystreams:to": {
+    "xdmImsUser:id": "D13A1E7053E46A220A4C86E1@AdobeID",
+    "@type": "xdmImsUser"
+  },
+  "activitystreams:generator": {
+    "xdmContentRepository:root": "https://cc-api-storage.adobe.io/",
+    "@type": "xdmContentRepository"
+  },
+  "activitystreams:actor": {
+    "xdmImsUser:id": "D13A1E7053E46A220A4C86E1@AdobeID",
+    "@type": "xdmImsUser"
+  },
+  "activitystreams:object": {
+    "@type": "xdmAsset",
+    "xdmAsset:asset_id": "urn:aaid:sc:us:4123ba4c-93a8-4c5d-b979-ffbbe4318185",
+    "xdmAsset:asset_name": "example.jpg",
+    "xdmAsset:etag": "6fc55d0389d856ae7deccebba54f110e",
+    "xdmAsset:path": "/MyFolder/example.jpg",
+    "xdmAsset:format": "image/jpeg"
+  },
+  "activitystreams:published": "1970-01-01T01:00:00.000+01",
+  "@context": {
+    "activitystreams": "http://www.w3.org/ns/activitystreams#",
+    "xdmEventEnvelope": "https://ns.adobe.com/xdm/common/eventenvelope#",
+    "xdmAsset": "http://ns.adobe.com/xdm/assets/asset#",
+    "xdmImsUser": "https://ns.adobe.com/xdm/ims/user#",
+    "xdmContentRepository": "https://ns.adobe.com/xdm/content/repository",
+    "xdmCreated": "https://ns.adobe.com/xdm/common/event/created#"
+  }
+}

--- a/events_xdm/src/test/resources/asset_deleted_aem_sample.json
+++ b/events_xdm/src/test/resources/asset_deleted_aem_sample.json
@@ -1,0 +1,31 @@
+{
+  "@id": "82235bac-2b81-4e70-90b5-2bd1f04b5c7b",
+  "@type": "xdmDeleted",
+  "xdmEventEnvelope:objectType": "xdmAsset",
+  "activitystreams:published": "1970-01-01T01:00:00.000+01",
+  "activitystreams:to": {
+    "xdmImsOrg:id": "08B3E5CE5822FC520A494229@AdobeOrg",
+    "@type": "xdmImsOrg"
+  },
+  "activitystreams:generator": {
+    "xdmContentRepository:root": "http://francois.corp.adobe.com:4502/",
+    "@type": "xdmContentRepository"
+  },
+  "activitystreams:actor": {
+    "xdmAemUser:id": "admin",
+    "@type": "xdmAemUser"
+  },
+  "activitystreams:object": {
+    "@type": "xdmAsset",
+    "xdmAsset:asset_id": "urn:aaid:aem:4123ba4c-93a8-4c5d-b979-ffbbe4318185"
+  },
+  "@context": {
+    "activitystreams": "http://www.w3.org/ns/activitystreams#",
+    "xdmEventEnvelope": "https://ns.adobe.com/xdm/common/eventenvelope#",
+    "xdmAsset": "http://ns.adobe.com/xdm/assets/asset#",
+    "xdmImsOrg": "https://ns.adobe.com/xdm/ims/organization#",
+    "xdmContentRepository": "https://ns.adobe.com/xdm/content/repository",
+    "xdmAemUser": "https://ns.adobe.com/xdm/aem/user#",
+    "xdmDeleted": "https://ns.adobe.com/xdm/common/event/deleted#"
+  }
+}

--- a/events_xdm/src/test/resources/asset_deleted_cc_sample.json
+++ b/events_xdm/src/test/resources/asset_deleted_cc_sample.json
@@ -1,0 +1,30 @@
+{
+  "@id": "82235bac-2b81-4e70-90b5-2bd1f04b5c7b",
+  "@type": "xdmDeleted",
+  "xdmEventEnvelope:objectType": "xdmAsset",
+  "activitystreams:to": {
+    "xdmImsUser:id": "D13A1E7053E46A220A4C86E1@AdobeID",
+    "@type": "xdmImsUser"
+  },
+  "activitystreams:generator": {
+    "xdmContentRepository:root": "https://cc-api-storage.adobe.io/",
+    "@type": "xdmContentRepository"
+  },
+  "activitystreams:actor": {
+    "xdmImsUser:id": "D13A1E7053E46A220A4C86E1@AdobeID",
+    "@type": "xdmImsUser"
+  },
+  "activitystreams:object": {
+    "@type": "xdmAsset",
+    "xdmAsset:asset_id": "urn:aaid:sc:us:4123ba4c-93a8-4c5d-b979-ffbbe4318185"
+  },
+  "activitystreams:published": "1970-01-01T01:00:00.000+01",
+  "@context": {
+    "activitystreams": "http://www.w3.org/ns/activitystreams#",
+    "xdmEventEnvelope": "https://ns.adobe.com/xdm/common/eventenvelope#",
+    "xdmAsset": "http://ns.adobe.com/xdm/assets/asset#",
+    "xdmImsUser": "https://ns.adobe.com/xdm/ims/user#",
+    "xdmContentRepository": "https://ns.adobe.com/xdm/content/repository",
+    "xdmDeleted": "https://ns.adobe.com/xdm/common/event/deleted#"
+  }
+}

--- a/events_xdm/src/test/resources/asset_updated_aem_sample.json
+++ b/events_xdm/src/test/resources/asset_updated_aem_sample.json
@@ -1,0 +1,36 @@
+{
+  "@id": "82235bac-2b81-4e70-90b5-2bd1f04b5c7b",
+  "@type": "xdmUpdated",
+  "xdmEventEnvelope:objectType": "xdmAsset",
+  "activitystreams:published":"1970-01-01T01:00:00.000+01",
+  "activitystreams:to": {
+    "xdmImsOrg:id": "08B3E5CE5822FC520A494229@AdobeOrg",
+    "@type": "xdmImsOrg"
+  },
+  "activitystreams:generator": {
+    "xdmContentRepository:root": "http://francois.corp.adobe.com:4502/",
+    "@type": "xdmContentRepository"
+  },
+  "activitystreams:actor": {
+    "xdmAemUser:id": "admin",
+    "@type": "xdmAemUser"
+  },
+  "activitystreams:object": {
+    "activitystreams:mediaType": "image/png",
+    "@type": "xdmAsset",
+    "xdmAsset:asset_id": "urn:aaid:aem:4123ba4c-93a8-4c5d-b979-ffbbe4318185",
+    "xdmAsset:asset_name": "Fx_DUKE-small.png",
+    "xdmAsset:etag": "6fc55d0389d856ae7deccebba54f110e",
+    "xdmAsset:path": "/content/dam/Fx_DUKE-small.png",
+    "xdmAsset:format": "image/png"
+  },
+  "@context": {
+    "activitystreams": "http://www.w3.org/ns/activitystreams#",
+    "xdmEventEnvelope": "https://ns.adobe.com/xdm/common/eventenvelope#",
+    "xdmAsset": "http://ns.adobe.com/xdm/assets/asset#",
+    "xdmImsOrg": "https://ns.adobe.com/xdm/ims/organization#",
+    "xdmContentRepository": "https://ns.adobe.com/xdm/content/repository",
+    "xdmAemUser": "https://ns.adobe.com/xdm/aem/user#",
+    "xdmUpdated": "https://ns.adobe.com/xdm/common/event/updated#"
+  }
+}

--- a/events_xdm/src/test/resources/asset_updated_cc_sample.json
+++ b/events_xdm/src/test/resources/asset_updated_cc_sample.json
@@ -1,0 +1,34 @@
+{
+  "@id": "82235bac-2b81-4e70-90b5-2bd1f04b5c7b",
+  "@type": "xdmUpdated",
+  "xdmEventEnvelope:objectType": "xdmAsset",
+  "activitystreams:to": {
+    "xdmImsUser:id": "D13A1E7053E46A220A4C86E1@AdobeID",
+    "@type": "xdmImsUser"
+  },
+  "activitystreams:generator": {
+    "xdmContentRepository:root": "https://cc-api-storage.adobe.io/",
+    "@type": "xdmContentRepository"
+  },
+  "activitystreams:actor": {
+    "xdmImsUser:id": "D13A1E7053E46A220A4C86E1@AdobeID",
+    "@type": "xdmImsUser"
+  },
+  "activitystreams:object": {
+    "@type": "xdmAsset",
+    "xdmAsset:asset_id": "urn:aaid:sc:us:4123ba4c-93a8-4c5d-b979-ffbbe4318185",
+    "xdmAsset:asset_name": "example.jpg",
+    "xdmAsset:etag": "6fc55d0389d856ae7deccebba54f110e",
+    "xdmAsset:path": "/MyFolder/example.jpg",
+    "xdmAsset:format": "image/jpeg"
+  },
+  "activitystreams:published": "1970-01-01T01:00:00.000+01",
+  "@context": {
+    "activitystreams": "http://www.w3.org/ns/activitystreams#",
+    "xdmEventEnvelope": "https://ns.adobe.com/xdm/common/eventenvelope#",
+    "xdmAsset": "http://ns.adobe.com/xdm/assets/asset#",
+    "xdmImsUser": "https://ns.adobe.com/xdm/ims/user#",
+    "xdmContentRepository": "https://ns.adobe.com/xdm/content/repository",
+    "xdmUpdated": "https://ns.adobe.com/xdm/common/event/updated#"
+  }
+}

--- a/events_xdm/src/test/resources/custom_osgi_emitted_aem_sample.json
+++ b/events_xdm/src/test/resources/custom_osgi_emitted_aem_sample.json
@@ -1,0 +1,33 @@
+{
+  "@id" : "82235bac-2b81-4e70-90b5-2bd1f04b5c7b",
+  "@type" : "xdmEmitted",
+  "activitystreams:published" : "1970-01-01T01:00:00.000+01",
+  "activitystreams:to" : {
+    "@type" : "xdmImsOrg",
+    "xdmImsOrg:id" : "08B3E5CE5822FC520A494229@AdobeOrg"
+  },
+  "activitystreams:generator" : {
+    "@type" : "xdmContentRepository",
+    "xdmContentRepository:root" : "http://francois.corp.adobe.com:4502/"
+  },
+  "activitystreams:object" : {
+    "@type" : "osgiEvent:io/adobe/event/sample/sku",
+    "osgiEvent:topic" : "io/adobe/event/sample/sku",
+    "osgiEvent:properties" : {
+      "type" : "created",
+      "id" : "1234"
+    }
+  },
+  "xdmEventEnvelope:objectType" : "osgiEvent:io/adobe/event/sample/sku",
+  "@context": {
+    "activitystreams": "http://www.w3.org/ns/activitystreams#",
+    "xdmEventEnvelope": "https://ns.adobe.com/xdm/common/eventenvelope#",
+    "xdmImsOrg": "https://ns.adobe.com/xdm/ims/organization#",
+    "xdmContentRepository": "https://ns.adobe.com/xdm/content/repository",
+    "xdmEmitted" : "https://ns.adobe.com/xdm/common/event/emitted#",
+    "osgiEvent" : "https://osgi.org/javadoc/r4v42/org/osgi/service/event/Event.html"
+  }
+}
+
+
+

--- a/events_xdm/src/test/resources/directory_created_cc_sample.json
+++ b/events_xdm/src/test/resources/directory_created_cc_sample.json
@@ -1,0 +1,34 @@
+{
+  "@id": "82235bac-2b81-4e70-90b5-2bd1f04b5c7b",
+  "@type": "xdmCreated",
+  "xdmEventEnvelope:objectType": "xdmDirectory",
+  "activitystreams:to": {
+    "xdmImsUser:id": "D13A1E7053E46A220A4C86E1@AdobeID",
+    "@type": "xdmImsUser"
+  },
+  "activitystreams:generator": {
+    "xdmContentRepository:root": "https://cc-api-storage.adobe.io/",
+    "@type": "xdmContentRepository"
+  },
+  "activitystreams:actor": {
+    "xdmImsUser:id": "D13A1E7053E46A220A4C86E1@AdobeID",
+    "@type": "xdmImsUser"
+  },
+  "activitystreams:object": {
+    "@type": "xdmDirectory",
+    "xdmDirectory:asset_id": "urn:aaid:sc:us:4123ba4c-93a8-4c5d-b979-ffbbe4318185",
+    "xdmDirectory:name": "example",
+    "xdmDirectory:etag": "6fc55d0389d856ae7deccebba54f110e",
+    "xdmDirectory:path": "/MyFolder/example",
+    "xdmDirectory:format": "application/vnd.adobecloud.directory+json"
+  },
+  "activitystreams:published": "1970-01-01T01:00:00.000+01",
+  "@context": {
+    "activitystreams": "http://www.w3.org/ns/activitystreams#",
+    "xdmEventEnvelope": "https://ns.adobe.com/xdm/common/eventenvelope#",
+    "xdmDirectory": "https://ns.adobe.com/adobecloud/core/1.0/directory#",
+    "xdmImsUser": "https://ns.adobe.com/xdm/ims/user#",
+    "xdmContentRepository": "https://ns.adobe.com/xdm/content/repository",
+    "xdmCreated": "https://ns.adobe.com/xdm/common/event/created#"
+  }
+}

--- a/events_xdm/src/test/resources/log4j.properties
+++ b/events_xdm/src/test/resources/log4j.properties
@@ -1,0 +1,17 @@
+#
+# Copyright 2017 Adobe. All rights reserved.
+# This file is licensed to you under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License. You may obtain a copy
+# of the License at http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software distributed under
+# the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+# OF ANY KIND, either express or implied. See the License for the specific language
+# governing permissions and limitations under the License.
+#
+
+log4j.rootLogger=INFO, stdout
+# Direct log messages to stdout
+log4j.appender.stdout=org.apache.log4j.ConsoleAppender
+log4j.appender.stdout.Target=System.out
+log4j.appender.stdout.layout=org.apache.log4j.PatternLayout

--- a/events_xdm/src/test/resources/page_published_aem_sample.json
+++ b/events_xdm/src/test/resources/page_published_aem_sample.json
@@ -1,0 +1,33 @@
+{
+  "@id": "82235bac-2b81-4e70-90b5-2bd1f04b5c7b",
+  "@type": "xdmPublished",
+  "xdmEventEnvelope:objectType": "xdmComponentizedPage",
+  "activitystreams:published": "1970-01-01T01:00:00.000+01",
+  "activitystreams:to": {
+    "xdmImsOrg:id": "08B3E5CE5822FC520A494229@AdobeOrg",
+    "@type": "xdmImsOrg"
+  },
+  "activitystreams:generator": {
+    "xdmContentRepository:root": "https://cloud-action-dev.corp.adobe.com:4502/",
+    "@type": "xdmContentRepository"
+  },
+  "activitystreams:actor": {
+    "xdmAemUser:id": "admin",
+    "@type": "xdmAemUser"
+  },
+  "activitystreams:object": {
+    "@id": "http://adobesummit.adobesandbox.com:4502/content/geometrixx/en/vintage.html",
+    "@type": "xdmComponentizedPage",
+    "xdmComponentizedPage:title": "Vintage Collection",
+    "xdmComponentizedPage:path": "/content/geometrixx/en/vintage.html"
+  },
+  "@context": {
+    "activitystreams": "http://www.w3.org/ns/activitystreams#",
+    "xdmEventEnvelope": "https://ns.adobe.com/xdm/common/eventenvelope#",
+    "xdmComponentizedPage": "https://ns.adobe.com/xdm/content/componentized-page#",
+    "xdmImsOrg": "https://ns.adobe.com/xdm/ims/organization#",
+    "xdmContentRepository": "https://ns.adobe.com/xdm/content/repository#",
+    "xdmAemUser": "https://ns.adobe.com/xdm/aem/user#",
+    "xdmPublished": "https://ns.adobe.com/xdm/common/event/published#"
+  }
+}

--- a/events_xdm/src/test/resources/page_unpublished_aem_sample.json
+++ b/events_xdm/src/test/resources/page_unpublished_aem_sample.json
@@ -1,0 +1,33 @@
+{
+  "@id": "82235bac-2b81-4e70-90b5-2bd1f04b5c7b",
+  "@type": "xdmUnpublished",
+  "xdmEventEnvelope:objectType": "xdmComponentizedPage",
+  "activitystreams:published":"1970-01-01T01:00:00.000+01",
+  "activitystreams:to": {
+    "xdmImsOrg:id": "08B3E5CE5822FC520A494229@AdobeOrg",
+    "@type": "xdmImsOrg"
+  },
+  "activitystreams:generator": {
+    "xdmContentRepository:root": "https://cloud-action-dev.corp.adobe.com:4502/",
+    "@type": "xdmContentRepository"
+  },
+  "activitystreams:actor": {
+    "xdmAemUser:id": "admin",
+    "@type": "xdmAemUser"
+  },
+  "activitystreams:object": {
+    "@id": "http://adobesummit.adobesandbox.com:4502/content/geometrixx/en/vintage.html",
+    "@type": "xdmComponentizedPage",
+    "xdmComponentizedPage:title": "Vintage Collection",
+    "xdmComponentizedPage:path": "/content/geometrixx/en/vintage.html"
+  },
+  "@context": {
+    "activitystreams": "http://www.w3.org/ns/activitystreams#",
+    "xdmEventEnvelope": "https://ns.adobe.com/xdm/common/eventenvelope#",
+    "xdmComponentizedPage": "https://ns.adobe.com/xdm/content/componentized-page#",
+    "xdmImsOrg": "https://ns.adobe.com/xdm/ims/organization#",
+    "xdmContentRepository": "https://ns.adobe.com/xdm/content/repository#",
+    "xdmAemUser": "https://ns.adobe.com/xdm/aem/user#",
+    "xdmPublished": "https://ns.adobe.com/xdm/common/event/published#"
+  }
+}

--- a/events_xdm/src/test/resources/xdm_context.json
+++ b/events_xdm/src/test/resources/xdm_context.json
@@ -1,0 +1,27 @@
+{
+  "@context": {
+    "activitystreams": "http://www.w3.org/ns/activitystreams#",
+
+    "xdmEventEnvelope": "http://ns.adobe.com/xdm/event-envelope#",
+
+    "xdmAsset": "http://ns.adobe.com/xdm/assets/asset#",
+    "xdmComponentizedPage": "http://ns.adobe.com/xdm/content/componentized-page#",
+
+    "xdmContentRepository": "http://ns.adobe.com/xdm/content/repository#",
+
+    "xdmImsOrg": "https://ns.adobe.com/xdm-extensions/ims/organization#",
+    "xdmAemUser": "https://ns.adobe.com/xdm-extensions/aem/user",
+    "xdmImsUser": "https://ns.adobe.com/xdm-extensions/ims/user#",
+
+    "xdmCreated": "https://ns.adobe.com/xdm/common/event/created#",
+    "xdmDeleted": "https://ns.adobe.com/xdm/common/event/deleted#",
+    "xdmUpdated": "https://ns.adobe.com/xdm/common/event/updated#",
+
+    "xdmPublished": "https://ns.adobe.com/xdm/common/event/published#",
+    "xdmUnpublished": "https://ns.adobe.com/xdm/common/event/unpublished#",
+
+    "xdmEmitted" : "https://ns.adobe.com/xdm/common/event/emitted#",
+
+    "osgiEvent" : "https://osgi.org/javadoc/r4v42/org/osgi/service/event/Event.html"
+  }
+}

--- a/ims/pom.xml
+++ b/ims/pom.xml
@@ -56,10 +56,9 @@
       <groupId>org.slf4j</groupId>
       <artifactId>slf4j-simple</artifactId>
     </dependency>
-
     <dependency>
       <groupId>junit</groupId>
-      <artifactId>junit-dep</artifactId>
+      <artifactId>junit</artifactId>
     </dependency>
 
   </dependencies>

--- a/ims/src/main/java/com/adobe/aio/ims/util/KeyStoreUtil.java
+++ b/ims/src/main/java/com/adobe/aio/ims/util/KeyStoreUtil.java
@@ -18,6 +18,7 @@ import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.nio.file.Paths;
 import java.security.KeyFactory;
 import java.security.KeyStore;
 import java.security.KeyStoreException;
@@ -55,7 +56,7 @@ public class KeyStoreUtil {
 
   public static PrivateKey getPrivateKeyFromPkcs8File(String filePath)
       throws IOException, InvalidKeySpecException, NoSuchAlgorithmException {
-    return getPrivateKeyFromPkcs8(Files.readAllBytes(Path.of(filePath)));
+    return getPrivateKeyFromPkcs8(Files.readAllBytes(Paths.get(filePath)));
   }
 
   private static PrivateKey getPrivateKeyFromPkcs8(byte[] pkcs8)

--- a/pom.xml
+++ b/pom.xml
@@ -194,7 +194,7 @@
 
       <dependency>
         <groupId>junit</groupId>
-        <artifactId>junit-dep</artifactId>
+        <artifactId>junit</artifactId>
         <version>${junit.version}</version>
         <scope>test</scope>
       </dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -30,6 +30,7 @@
     <module>events_journal</module>
 
     <module>events_test</module>
+    <module>events_xdm</module>
 
     <module>aem</module>
 
@@ -116,14 +117,6 @@
   <dependencyManagement>
     <dependencies>
 
-      <!-- adobe.io XDM event model -->
-      <dependency>
-        <groupId>com.adobe.event</groupId>
-        <artifactId>xdm-event-model</artifactId>
-        <version>${xdm.event-model.version}</version>
-        <scope>provided</scope>
-      </dependency>
-
       <dependency>
         <groupId>org.apache.commons</groupId>
         <artifactId>commons-text</artifactId>
@@ -164,6 +157,12 @@
         <groupId>jakarta.xml.bind</groupId>
         <artifactId>jakarta.xml.bind-api</artifactId>
         <version>3.0.1</version>
+      </dependency>
+
+      <dependency>
+        <groupId>com.fasterxml.jackson.core</groupId>
+        <artifactId>jackson-annotations</artifactId>
+        <version>${jackson.version}</version>
       </dependency>
 
       <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -110,8 +110,7 @@
 
     <feign.version>11.2</feign.version>
     <feign-form.version>3.8.0</feign-form.version>
-    
-    <xdm.event-model.version>0.92.6-SNAPSHOT</xdm.event-model.version>
+
   </properties>
 
   <dependencyManagement>

--- a/pom.xml
+++ b/pom.xml
@@ -110,7 +110,7 @@
     <feign.version>11.2</feign.version>
     <feign-form.version>3.8.0</feign-form.version>
     
-    <xdm.event-model.version>0.92.5</xdm.event-model.version>
+    <xdm.event-model.version>0.92.6-SNAPSHOT</xdm.event-model.version>
   </properties>
 
   <dependencyManagement>
@@ -369,8 +369,8 @@
           <artifactId>maven-compiler-plugin</artifactId>
           <version>3.10.1</version>
           <configuration>
-            <source>11</source>
-            <target>11</target>
+            <source>1.8</source>
+            <target>1.8</target>
           </configuration>
         </plugin>
 
@@ -427,7 +427,7 @@
           <artifactId>maven-javadoc-plugin</artifactId>
           <version>3.3.2</version>
           <configuration>
-            <source>11</source>
+            <source>1.8</source>
             <notimestamp>true</notimestamp>
             <quiet>true</quiet>
             <doctitle>Adobe I/O - Java SDK API v${project.version}</doctitle>


### PR DESCRIPTION
## Description

* downgrading the java compiler's source and target to support jdk8 users 
* the XDM Adobe I/O Events Model has find here a new home and a new name
  *  relocating `com.adobe.event:xdm-event-model` as a new module of this repo 
  *  renaming it to `com.adobe.aio:aio-lib-java-events-xdm` 
* other minor updates:
  * aligning with the relocation of The artifact junit:junit-dep:jar:4.11 to junit:junit:jar:4.11
  * polishing: adding a few `README.md` details
  * fixing typo 

## Related Issue

* GH-21
* GH-104