### PR TITLE
GH-142 fixing `aio-lib-osgi` : it now exports `io.openapitools.jackson.dataformat.hal.*` packages

### DIFF
--- a/aem/core_aem/pom.xml
+++ b/aem/core_aem/pom.xml
@@ -73,6 +73,7 @@
         <dependency>
           <groupId>com.adobe.aem</groupId>
           <artifactId>aem-sdk-api</artifactId>
+          <version>${aemaacs.version}</version>
         </dependency>
       </dependencies>
     </profile>

--- a/aem/events_ingress_aem/pom.xml
+++ b/aem/events_ingress_aem/pom.xml
@@ -73,6 +73,7 @@
         <dependency>
           <groupId>com.adobe.aem</groupId>
           <artifactId>aem-sdk-api</artifactId>
+          <version>${aemaacs.version}</version>
         </dependency>
       </dependencies>
     </profile>

--- a/aem/events_mgmt_aem/pom.xml
+++ b/aem/events_mgmt_aem/pom.xml
@@ -61,6 +61,7 @@
         <dependency>
           <groupId>com.adobe.aem</groupId>
           <artifactId>aem-sdk-api</artifactId>
+          <version>${aemaacs.version}</version>
         </dependency>
       </dependencies>
     </profile>

--- a/aem/events_osgi_mapping/pom.xml
+++ b/aem/events_osgi_mapping/pom.xml
@@ -81,6 +81,7 @@
         <dependency>
           <groupId>com.adobe.aem</groupId>
           <artifactId>aem-sdk-api</artifactId>
+          <version>${aemaacs.version}</version>
         </dependency>
       </dependencies>
     </profile>

--- a/aem/lib_osgi/src/main/bnd/aio-lib-osgi.bnd
+++ b/aem/lib_osgi/src/main/bnd/aio-lib-osgi.bnd
@@ -43,7 +43,8 @@ Export-Package: com.adobe.aio.workspace;version="${project.version}";provide:=tr
     com.adobe.aio.event.journal.model;version="${project.version}";provide:=true,\
     com.adobe.aio.event.publish;version="${project.version}";provide:=true,\
     com.adobe.aio.event.publish.model;version="${project.version}";provide:=true,\
-    com.adobe.xdm.*;version="${project.version}";provide:=true
+    com.adobe.xdm.*;version="${project.version}";provide:=true, \
+    io.openapitools.jackson.dataformat.hal.*;version="${jackson-dataformat-hal.version}";provide:=true
 Bundle-DocURL:
 
 -noextraheaders: true

--- a/aem/pom.xml
+++ b/aem/pom.xml
@@ -49,6 +49,9 @@
     <crx.password>admin</crx.password>
     <crx.port>4502</crx.port>
     <crx.path>/apps/aio/install</crx.path>
+
+    <aemaacs.version>2021.11.6013.20211105T162756Z-211000</aemaacs.version>
+
     <!--
 If you want to deploy the bundle from the source
 1. modify the below `crx.*` properties according to your needs
@@ -208,15 +211,12 @@ If you want to deploy the bundle from the source
       <activation>
         <activeByDefault>true</activeByDefault>
       </activation>
-      <properties>
-        <aem.version>2021.11.6013.20211105T162756Z-211000</aem.version>
-      </properties>
       <dependencyManagement>
         <dependencies>
           <dependency>
             <groupId>com.adobe.aem</groupId>
             <artifactId>aem-sdk-api</artifactId>
-            <version>${aem.version}</version>
+            <version>${aemaacs.version}</version>
             <scope>provided</scope>
           </dependency>
         </dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -109,7 +109,7 @@
     <jjwt.version>0.11.2</jjwt.version>
     <cloudevents.version>1.2.0</cloudevents.version>
 
-    <!-- https://github.com/openapi-tools/jackson-dataformat-hal/blob/v1.0.7/pom.xml -->
+    <!-- https://github.com/openapi-tools/jackson-dataformat-hal/blob/v1.0.9/pom.xml -->
     <jackson-dataformat-hal.version>1.0.9</jackson-dataformat-hal.version>
 
     <feign.version>11.2</feign.version>


### PR DESCRIPTION
## Description

 fixing `aio-lib-osgi` : it now exports `io.openapitools.jackson.dataformat.hal.*` packages

## Related Issue

* GH-142
