### PR TITLE
GH-157: expose a timeout configurable `pollJournalForEvents` method

### DIFF
--- a/events_test/src/main/java/com/adobe/aio/event/journal/JournalServiceTester.java
+++ b/events_test/src/main/java/com/adobe/aio/event/journal/JournalServiceTester.java
@@ -79,12 +79,28 @@ public class JournalServiceTester {
 
   /**
    * Polls the journal for the given eventIds. The journal is polled until all eventIds are found.
+   * The timeout is set to 2 minutes.
    * @param journalUrl        The journal url
    * @param eventIds          The eventIds to find (the set is not modified)
    * @param isEventIdInEvent  The predicate to use to find the eventIds in the journal
    * @return true if all eventIds are found, false otherwise (if timeout is reached).
    */
-  public boolean pollJournalForEvents(String journalUrl, Set<String> eventIds, BiPredicate<Event, String> isEventIdInEvent) {
+  public boolean pollJournalForEvents(String journalUrl, Set<String> eventIds,
+      BiPredicate<Event, String> isEventIdInEvent) {
+    return pollJournalForEvents(journalUrl, eventIds, isEventIdInEvent,
+        JOURNAL_POLLING_TIME_OUT_IN_MILLISECONDS);
+  }
+
+  /**
+   * Polls the journal for the given eventIds. The journal is polled until all eventIds are found.
+   * @param journalUrl            The journal url
+   * @param eventIds              The eventIds to find (the set is not modified)
+   * @param isEventIdInEvent      The predicate to use to find the eventIds in the journal
+   * @param timeoutInMilliseconds The timeout in milliseconds
+   * @return true if all eventIds are found, false otherwise (if timeout is reached).
+   */
+  public boolean pollJournalForEvents(String journalUrl, Set<String> eventIds,
+      BiPredicate<Event, String> isEventIdInEvent, long timeoutInMilliseconds) {
     JournalService journalService = JournalService.builder()
         .workspace(workspace)
         .url(journalUrl)
@@ -121,7 +137,7 @@ public class JournalServiceTester {
         logger.error("Interrupted while sleeping", e);
       }
       entry = journalService.get(entry.getNextLink());
-    } while(pollingDuration < JOURNAL_POLLING_TIME_OUT_IN_MILLISECONDS);
+    } while(pollingDuration < timeoutInMilliseconds);
     // We did not find all eventIds in the journal, signal it.
     logger.error("We polled the journal for " + JOURNAL_POLLING_TIME_OUT_IN_MILLISECONDS
         + " milliseconds and could NOT find the expected eventIds.");


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Adding a new overload for method `pollJournalForEvents` which accepts a timeout in millis as parameter, maintaining also the default 2 minutes method that was already implemented.

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
<!--- Please list as well any other related PRs/commits in other repositories (or any other dependencies) -->
Solves: #157 

## Motivation and Context

To load test the application, we might require to enlarge the timeout to retrieve multiple events from the Journal.
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [ ] My code follows the [code style](CODE_STYLE.md) of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.




