### PR TITLE
GH-157: fix iterator over set with removal bug in `JournalServiceTester`

### DIFF
--- a/events_test/src/main/java/com/adobe/aio/event/journal/JournalServiceTester.java
+++ b/events_test/src/main/java/com/adobe/aio/event/journal/JournalServiceTester.java
@@ -18,6 +18,7 @@ import com.adobe.aio.event.journal.model.JournalEntry;
 import com.adobe.aio.util.WorkspaceUtil;
 import com.adobe.aio.workspace.Workspace;
 import java.util.HashSet;
+import java.util.Iterator;
 import java.util.Set;
 import java.util.function.BiPredicate;
 import org.slf4j.Logger;
@@ -114,10 +115,11 @@ public class JournalServiceTester {
       if (!entry.isEmpty()) {
         for (Event event : entry.getEvents()) {
           logger.debug("Journal Event {}: ", event);
-          for (String eventId : eventIdsToFind) {
+          for (Iterator<String> it = eventIdsToFind.iterator(); it.hasNext(); ) {
+            String eventId = it.next();
             if (isEventIdInEvent.test(event, eventId)) {
               logger.info("EventId {} found in a cloudEvent in this journal entry", eventId);
-              eventIdsToFind.remove(eventId);
+              it.remove();
             }
           }
         }


### PR DESCRIPTION
## Description

removing elements from a set in an enhanced for loop is not possible, changing to the explicit iterator to be able to remove  eventsIds that we retrieve from the journal.

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
<!--- Please list as well any other related PRs/commits in other repositories (or any other dependencies) -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [ ] My code follows the [code style](CODE_STYLE.md) of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.




