### PR TITLE
Some proposal for better Backward compatibility

### DIFF
--- a/core/src/main/java/com/adobe/aio/workspace/Workspace.java
+++ b/core/src/main/java/com/adobe/aio/workspace/Workspace.java
@@ -147,6 +147,18 @@ public class Workspace {
     return authContext;
   }
 
+  /**
+   * @deprecated This will be removed in v2.0 of the library.
+   */
+  @Deprecated
+  public String getCredentialId() {
+    if (authContext instanceof JwtContext) {
+      return ((JwtContext) authContext).getCredentialId();
+    } else {
+      return null;
+    }
+  }
+
   @Override
   public boolean equals(Object o) {
     if (this == o) {

--- a/events_ingress/src/test/java/com/adobe/aio/event/publish/feign/FeignPublishServiceTestDrive.java
+++ b/events_ingress/src/test/java/com/adobe/aio/event/publish/feign/FeignPublishServiceTestDrive.java
@@ -14,7 +14,7 @@ package com.adobe.aio.event.publish.feign;
 import com.adobe.aio.event.publish.PublishService;
 import com.adobe.aio.event.publish.model.CloudEvent;
 import com.adobe.aio.util.JacksonUtil;
-import com.adobe.aio.ims.util.WorkspaceUtil;
+import com.adobe.aio.util.WorkspaceUtil;
 import com.adobe.aio.workspace.Workspace;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;

--- a/events_journal/src/test/java/com/adobe/aio/event/journal/feign/FeignJournalServiceTestDrive.java
+++ b/events_journal/src/test/java/com/adobe/aio/event/journal/feign/FeignJournalServiceTestDrive.java
@@ -13,7 +13,7 @@ package com.adobe.aio.event.journal.feign;
 
 import com.adobe.aio.event.journal.JournalService;
 import com.adobe.aio.event.journal.model.JournalEntry;
-import com.adobe.aio.ims.util.WorkspaceUtil;
+import com.adobe.aio.util.WorkspaceUtil;
 import com.adobe.aio.workspace.Workspace;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;

--- a/events_mgmt/src/test/java/com/adobe/aio/event/management/feign/FeignProviderServiceTestDrive.java
+++ b/events_mgmt/src/test/java/com/adobe/aio/event/management/feign/FeignProviderServiceTestDrive.java
@@ -15,7 +15,7 @@ import com.adobe.aio.event.management.ProviderService;
 import com.adobe.aio.event.management.model.EventMetadata;
 import com.adobe.aio.event.management.model.Provider;
 import com.adobe.aio.event.management.model.ProviderInputModel;
-import com.adobe.aio.ims.util.WorkspaceUtil;
+import com.adobe.aio.util.WorkspaceUtil;
 import com.adobe.aio.workspace.Workspace;
 import java.util.List;
 import java.util.Optional;

--- a/events_mgmt/src/test/java/com/adobe/aio/event/management/feign/FeignRegistrationServiceTestDrive.java
+++ b/events_mgmt/src/test/java/com/adobe/aio/event/management/feign/FeignRegistrationServiceTestDrive.java
@@ -13,7 +13,7 @@ package com.adobe.aio.event.management.feign;
 
 import com.adobe.aio.event.management.RegistrationService;
 import com.adobe.aio.event.management.model.RegistrationCreateModel;
-import com.adobe.aio.ims.util.WorkspaceUtil;
+import com.adobe.aio.util.WorkspaceUtil;
 import com.adobe.aio.workspace.Workspace;
 import com.adobe.aio.event.management.model.EventsOfInterestInputModel;
 import com.adobe.aio.event.management.model.Registration;

--- a/events_test/src/main/java/com/adobe/aio/event/journal/JournalServiceTester.java
+++ b/events_test/src/main/java/com/adobe/aio/event/journal/JournalServiceTester.java
@@ -15,7 +15,7 @@ import static com.adobe.aio.event.publish.PublishServiceTester.DATA_EVENT_ID_NOD
 
 import com.adobe.aio.event.journal.model.Event;
 import com.adobe.aio.event.journal.model.JournalEntry;
-import com.adobe.aio.ims.util.WorkspaceUtil;
+import com.adobe.aio.util.WorkspaceUtil;
 import com.adobe.aio.workspace.Workspace;
 import java.util.HashSet;
 import java.util.Iterator;

--- a/events_test/src/main/java/com/adobe/aio/event/management/ProviderServiceTester.java
+++ b/events_test/src/main/java/com/adobe/aio/event/management/ProviderServiceTester.java
@@ -15,7 +15,7 @@ import com.adobe.aio.event.management.model.EventMetadata;
 import com.adobe.aio.event.management.model.Provider;
 import com.adobe.aio.event.management.model.ProviderInputModel;
 import com.adobe.aio.event.publish.model.CloudEvent;
-import com.adobe.aio.ims.util.WorkspaceUtil;
+import com.adobe.aio.util.WorkspaceUtil;
 import com.adobe.aio.workspace.Workspace;
 
 import java.util.Collections;

--- a/events_test/src/main/java/com/adobe/aio/event/management/RegistrationServiceTester.java
+++ b/events_test/src/main/java/com/adobe/aio/event/management/RegistrationServiceTester.java
@@ -15,7 +15,7 @@ import com.adobe.aio.event.management.model.EventsOfInterest;
 import com.adobe.aio.event.management.model.EventsOfInterestInputModel;
 import com.adobe.aio.event.management.model.Registration;
 import com.adobe.aio.event.management.model.RegistrationCreateModel;
-import com.adobe.aio.ims.util.WorkspaceUtil;
+import com.adobe.aio.util.WorkspaceUtil;
 import com.adobe.aio.workspace.Workspace;
 import java.net.MalformedURLException;
 import java.net.URL;

--- a/events_test/src/main/java/com/adobe/aio/event/publish/PublishServiceTester.java
+++ b/events_test/src/main/java/com/adobe/aio/event/publish/PublishServiceTester.java
@@ -14,7 +14,7 @@ package com.adobe.aio.event.publish;
 import static com.adobe.aio.event.publish.model.CloudEvent.SPEC_VERSION;
 
 import com.adobe.aio.event.publish.model.CloudEvent;
-import com.adobe.aio.ims.util.WorkspaceUtil;
+import com.adobe.aio.util.WorkspaceUtil;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import java.util.UUID;
 import org.slf4j.Logger;

--- a/events_test/src/test/java/com/adobe/aio/event/journal/JournalServiceIntegrationTest.java
+++ b/events_test/src/test/java/com/adobe/aio/event/journal/JournalServiceIntegrationTest.java
@@ -18,7 +18,7 @@ import com.adobe.aio.event.management.ProviderServiceTester;
 import com.adobe.aio.event.management.RegistrationServiceTester;
 import com.adobe.aio.event.management.model.Registration;
 import com.adobe.aio.event.publish.PublishServiceTester;
-import com.adobe.aio.ims.util.WorkspaceUtil;
+import com.adobe.aio.util.WorkspaceUtil;
 import org.junit.jupiter.api.Test;
 
 import static com.adobe.aio.event.management.ProviderServiceIntegrationTest.*;

--- a/events_test/src/test/java/com/adobe/aio/event/management/ProviderServiceIntegrationTest.java
+++ b/events_test/src/test/java/com/adobe/aio/event/management/ProviderServiceIntegrationTest.java
@@ -17,7 +17,7 @@ import java.util.Optional;
 import com.adobe.aio.event.management.feign.ConflictException;
 import com.adobe.aio.event.management.model.EventMetadata;
 import com.adobe.aio.event.management.model.Provider;
-import com.adobe.aio.ims.util.WorkspaceUtil;
+import com.adobe.aio.util.WorkspaceUtil;
 import org.junit.jupiter.api.Test;
 
 import static com.adobe.aio.event.management.model.ProviderInputModel.*;

--- a/ims/src/main/java/com/adobe/aio/util/WorkspaceUtil.java
+++ b/ims/src/main/java/com/adobe/aio/util/WorkspaceUtil.java
@@ -9,9 +9,9 @@
  * OF ANY KIND, either express or implied. See the License for the specific language
  * governing permissions and limitations under the License.
  */
-package com.adobe.aio.ims.util;
+package com.adobe.aio.util;
 
-import com.adobe.aio.util.FileUtil;
+import com.adobe.aio.ims.util.PrivateKeyBuilder;
 import com.adobe.aio.workspace.Workspace;
 import java.security.PrivateKey;
 import java.util.Properties;
@@ -63,7 +63,10 @@ public class WorkspaceUtil {
   public static String getSystemProperty(String key, String propertyClassPath) {
     String value = System.getProperty(key);
     if (StringUtils.isBlank(value)) {
+      logger.debug("loading property `{}` from classpath `{}`", key, propertyClassPath);
       value = FileUtil.readPropertiesFromClassPath(propertyClassPath).getProperty(key);
+    } else {
+      logger.debug("loading property `{}`from JVM System Properties", key);
     }
     return value;
   }

--- a/ims/src/test/java/com/adobe/aio/ims/feign/FeignImsServiceIntegrationTest.java
+++ b/ims/src/test/java/com/adobe/aio/ims/feign/FeignImsServiceIntegrationTest.java
@@ -13,7 +13,7 @@ package com.adobe.aio.ims.feign;
 
 import com.adobe.aio.ims.ImsService;
 import com.adobe.aio.ims.model.AccessToken;
-import com.adobe.aio.ims.util.WorkspaceUtil;
+import com.adobe.aio.util.WorkspaceUtil;
 import com.adobe.aio.workspace.Workspace;
 import feign.FeignException;
 import org.junit.jupiter.api.Test;

--- a/ims/src/test/java/com/adobe/aio/ims/feign/FeignImsServiceTestDrive.java
+++ b/ims/src/test/java/com/adobe/aio/ims/feign/FeignImsServiceTestDrive.java
@@ -12,7 +12,7 @@
 package com.adobe.aio.ims.feign;
 
 import com.adobe.aio.ims.ImsService;
-import com.adobe.aio.ims.util.WorkspaceUtil;
+import com.adobe.aio.util.WorkspaceUtil;
 import com.adobe.aio.workspace.Workspace;
 import com.adobe.aio.ims.model.AccessToken;
 import com.adobe.aio.ims.util.PrivateKeyBuilder;


### PR DESCRIPTION
* re-introducing `Workspace.getCredentialId()`
* moving back `WorkspaceUtil` to  `com.adobe.aio.util`

