### PR TITLE
Let's stick to the old CloudEvents v1 spec and package for now

### DIFF
--- a/core/src/main/java/com/adobe/aio/util/JacksonUtil.java
+++ b/core/src/main/java/com/adobe/aio/util/JacksonUtil.java
@@ -20,7 +20,8 @@ import com.fasterxml.jackson.databind.json.JsonMapper;
 import com.fasterxml.jackson.databind.module.SimpleModule;
 import com.fasterxml.jackson.databind.node.TextNode;
 import com.fasterxml.jackson.datatype.jdk8.Jdk8Module;
-import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
+import io.cloudevents.json.ZonedDateTimeDeserializer;
+import io.cloudevents.json.ZonedDateTimeSerializer;
 import io.openapitools.jackson.dataformat.hal.JacksonHALModule;
 import java.time.ZonedDateTime;
 import org.apache.commons.lang3.StringUtils;
@@ -31,13 +32,16 @@ public class JacksonUtil {
   }
 
   public static final ObjectMapper DEFAULT_OBJECT_MAPPER =
-    JsonMapper.builder()
-      .configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false)
-      .serializationInclusion(Include.NON_NULL)
-      .addModule(new JacksonHALModule())
-      .addModule(new Jdk8Module())
-      .addModule(new JavaTimeModule())
-      .build();
+      JsonMapper.builder()
+          .configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false)
+          .serializationInclusion(Include.NON_NULL)
+          .addModule(new SimpleModule()
+              .addSerializer(ZonedDateTime.class, new ZonedDateTimeSerializer())
+              .addDeserializer(ZonedDateTime.class, new ZonedDateTimeDeserializer()))
+           // let's stick to CloudEvents v1 ISO_OFFSET_DATE_TIME date format
+          .addModule(new JacksonHALModule())
+          .addModule(new Jdk8Module())
+          .build();
 
   public static JsonNode getJsonNode(String jsonPayload) throws JsonProcessingException {
     if (StringUtils.isEmpty(jsonPayload)) {

--- a/pom.xml
+++ b/pom.xml
@@ -103,7 +103,9 @@
     <slf4j.version>2.0.7</slf4j.version>
     <jackson.version>2.15.2</jackson.version>
     <jjwt.version>0.11.5</jjwt.version>
-    <cloudevents.version>2.5.0</cloudevents.version>
+
+    <cloudevents.version>1.2.0</cloudevents.version>
+    <!--  we'll stick to this CloudEvents v1 version for now -->
 
     <!-- https://github.com/openapi-tools/jackson-dataformat-hal/blob/v1.0.9/pom.xml -->
     <jackson-dataformat-hal.version>1.0.9</jackson-dataformat-hal.version>


### PR DESCRIPTION
Let's stick to the old CloudEvents v1 spec and package for now
as we did not test the latest package and as this format is key to our partners integration

