### PR TITLE
GH-170 downgrading `maven-install-plugin` to `2.5.2`

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -399,7 +399,7 @@
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-install-plugin</artifactId>
-          <version>3.1.1</version>
+          <version>2.5.2</version>
         </plugin>
 
         <plugin>


### PR DESCRIPTION
As it looks like 3.1.1 has a similar bug to https://issues.apache.org/jira/browse/MINSTALL-151 that prevents our `aem65` profile to run


see https://github.com/adobe/aio-lib-java/issues/170 