### PR TITLE
GH-182 - downgrade jackson and slf4j: to work-around missing AEM support…

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -100,8 +100,8 @@
     <commons-lang3.version>3.13.0</commons-lang3.version>
     <junit.version>5.10.0</junit.version>
     <mockito.version>5.4.0</mockito.version>
-    <slf4j.version>2.0.7</slf4j.version>
-    <jackson.version>2.15.2</jackson.version>
+    <slf4j.version>1.7.6</slf4j.version>
+    <jackson.version>2.13.4</jackson.version>
     <jjwt.version>0.11.5</jjwt.version>
 
     <cloudevents.version>1.2.0</cloudevents.version>


### PR DESCRIPTION
## Description

downgrade jackson and slf4j: to work-around missing AEM support  (see #183)

## Related Issue

#182 

