### PR TITLE
Remove all references to deprecated Jakarta libraries

### DIFF
--- a/aem/lib_osgi/pom.xml
+++ b/aem/lib_osgi/pom.xml
@@ -72,11 +72,6 @@
     </dependency>
 
     <dependency>
-      <artifactId>jakarta.xml.bind-api</artifactId>
-      <groupId>jakarta.xml.bind</groupId>
-    </dependency>
-
-    <dependency>
       <artifactId>feign-core</artifactId>
       <groupId>io.github.openfeign</groupId>
     </dependency>

--- a/ims/pom.xml
+++ b/ims/pom.xml
@@ -33,12 +33,6 @@
       <artifactId>aio-lib-java-core</artifactId>
       <version>${project.version}</version>
     </dependency>
-
-    <dependency>
-      <groupId>jakarta.xml.bind</groupId>
-      <artifactId>jakarta.xml.bind-api</artifactId>
-    </dependency>
-
     <dependency>
       <groupId>io.jsonwebtoken</groupId>
       <artifactId>jjwt-api</artifactId>

--- a/ims/src/main/java/com/adobe/aio/ims/util/KeyStoreUtil.java
+++ b/ims/src/main/java/com/adobe/aio/ims/util/KeyStoreUtil.java
@@ -11,13 +11,9 @@
  */
 package com.adobe.aio.ims.util;
 
-import jakarta.xml.bind.DatatypeConverter;
-import java.io.File;
 import java.io.FileInputStream;
 import java.io.IOException;
-import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
-import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.security.KeyFactory;
 import java.security.KeyStore;
@@ -28,11 +24,11 @@ import java.security.UnrecoverableKeyException;
 import java.security.cert.CertificateException;
 import java.security.spec.InvalidKeySpecException;
 import java.security.spec.PKCS8EncodedKeySpec;
+import java.util.Base64;
 
 public class KeyStoreUtil {
 
   private static final String PKCS_12 = "PKCS12";
-  private static final String UTF_8 = "UTF-8";
   private static final String RSA = "RSA";
 
   private KeyStoreUtil() {
@@ -48,10 +44,7 @@ public class KeyStoreUtil {
 
   public static PrivateKey getPrivateKeyFromEncodedPkcs8(String base64EncodedPkcs8)
       throws InvalidKeySpecException, NoSuchAlgorithmException {
-    return getPrivateKeyFromPkcs8(
-        DatatypeConverter.parseBase64Binary(
-            new String(base64EncodedPkcs8.getBytes(), StandardCharsets.UTF_8))
-    );
+    return getPrivateKeyFromPkcs8(Base64.getDecoder().decode(base64EncodedPkcs8));
   }
 
   public static PrivateKey getPrivateKeyFromPkcs8File(String filePath)

--- a/pom.xml
+++ b/pom.xml
@@ -173,12 +173,6 @@
       </dependency>
 
       <dependency>
-        <groupId>jakarta.xml.bind</groupId>
-        <artifactId>jakarta.xml.bind-api</artifactId>
-        <version>4.0.0</version>
-      </dependency>
-
-      <dependency>
         <groupId>com.fasterxml.jackson.core</groupId>
         <artifactId>jackson-annotations</artifactId>
         <version>${jackson.version}</version>


### PR DESCRIPTION
## Description

The Jakarta Bind API has been deprecated. The only use in this library is for Binary handling, which is part of Java8 API.

## Motivation and Context

Jakarta dependency causes collisions with downstream libraries.
see https://github.com/adobe/aio-lib-java/issues/193 

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the [code style](CODE_STYLE.md) of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.




