### PR TITLE
`aio-lib-osgi` added export instruction for auth package (#202)

### DIFF
--- a/aem/lib_osgi/src/main/bnd/aio-lib-osgi.bnd
+++ b/aem/lib_osgi/src/main/bnd/aio-lib-osgi.bnd
@@ -32,6 +32,7 @@ Import-Package: \
     com.fasterxml.jackson.databind.type;version="[2.9,3)",\
     *
 Export-Package: com.adobe.aio.workspace;version="${project.version}";provide:=true,\
+    com.adobe.aio.auth;version="${project.version}";provide:=true,\
     com.adobe.aio.exception;version="${project.version}";provide:=true,\
     com.adobe.aio.util;version="${project.version}";provide:=true,\
     com.adobe.aio.ims;version="${project.version}";provide:=true,\


### PR DESCRIPTION
## Description

Recently we upgraded to 1.1.12 version of the sdk and started using com.adobe.aio.auth but we were not able to start our bundle on AEM since the artifact aio-lib-osgi is not exporting this package. Added this package in the export list so that the dependent bundles can access the classes of this package.

## Related Issue

* GH-186
* https://github.com/adobe/aio-lib-java/pull/202


## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the [code style](CODE_STYLE.md) of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.




