### PR TITLE
GH-204 Setting the `--release` of the Java Compiler: to stick to Java `8` avoid accidental Java `11` api use

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,5 @@
-
 ### Eclipse ###
+.DS_Store
 *.pydevproject
 .metadata
 .gradle

--- a/pom.xml
+++ b/pom.xml
@@ -383,10 +383,9 @@
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-compiler-plugin</artifactId>
-          <version>3.11.0</version>
+          <version>3.12.0</version>
           <configuration>
-            <source>1.8</source>
-            <target>1.8</target>
+            <release>8</release>
           </configuration>
         </plugin>
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
By using the source and target version configuration of maven-compiler-plugin we have no way to control the usage of Java 11 specific API. The compilation will still work but the code will fail at runtime when the jar is used with Java 8. 

<!--- Describe your changes in detail -->
Until Java 8, the only way to cross compile was to use source and target versions but these configuration params do not check the compatibility of the API against the specified Java version. 
Starting with Java 9 we have a stricter configuration when we are cross compiling. Earlier we were using JDK 8 for compiling but since now we are using JDK 11 it is better to add this release tag to ensure Java 8 compatibility in the released jar.

Refer this link for more details: https://maven.apache.org/plugins/maven-compiler-plugin/examples/set-compiler-release.html

Example usage of Java 11 API:
```List<String> myList = List.of("some", "new", "java", "code");```

Error for using the above line
```
[ERROR] Failed to execute goal org.apache.maven.plugins:maven-compiler-plugin:3.12.0:compile (default-compile) on project aio-lib-java-ims: Compilation failure
[ERROR] /Users/pulgupta/Documents/codes/aio-lib-java/ims/src/main/java/com/adobe/aio/ims/util/KeyStoreUtil.java:[36,31] cannot find symbol
[ERROR]   symbol:   method of(java.lang.String,java.lang.String,java.lang.String,java.lang.String)
[ERROR]   location: interface java.util.List
```


## Related Issue
https://github.com/adobe/aio-lib-java/issues/204

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
<!--- Please list as well any other related PRs/commits in other repositories (or any other dependencies) -->

## Motivation and Context
Since we are now building the project with Java 11 we have to ensure that we are not using any java 11/9 released API in the code. It will ensure that we are always compatible with Java 8

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
Verified that the compilation is failing on using java 11 features. 
Also verified that the generated jar is compatible with java 8
`javap -cp ims/target/aio-lib-java-ims-1.1.17-SNAPSHOT.jar -verbose com.adobe.aio.ims.util.KeyStoreUtil | grep major`

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [ ] My code follows the [code style](CODE_STYLE.md) of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.




