### PR TITLE
GH-204 Setting the `--release `of the Java Compiler: to stick to Java 8 and avoid accidental Java 11 api use

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,5 @@
-
 ### Eclipse ###
+.DS_Store
 *.pydevproject
 .metadata
 .gradle

--- a/pom.xml
+++ b/pom.xml
@@ -383,10 +383,9 @@
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-compiler-plugin</artifactId>
-          <version>3.11.0</version>
+          <version>3.12.0</version>
           <configuration>
-            <source>1.8</source>
-            <target>1.8</target>
+            <release>8</release>
           </configuration>
         </plugin>
 

--- a/pom.xml
+++ b/pom.xml
@@ -383,7 +383,7 @@
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-compiler-plugin</artifactId>
-          <version>3.12.0</version>
+          <version>3.12.1</version>
           <configuration>
             <release>8</release>
           </configuration>


### PR DESCRIPTION

## Description

By using the source and target version configuration of maven-compiler-plugin we have no way to control the usage of Java 11 specific API. The compilation will still work but the code will fail at runtime when the jar is used with Java 8. 

<!--- Describe your changes in detail -->
Until Java 8, the only way to cross compile was to use source and target versions but these configuration params do not check the compatibility of the API against the specified Java version. 
Starting with Java 9 we have a stricter configuration when we are cross compiling. Earlier we were using JDK 8 for compiling but since now we are using JDK 11 it is better to add this release tag to ensure Java 8 compatibility in the released jar.

Refer this link for more details: https://maven.apache.org/plugins/maven-compiler-plugin/examples/set-compiler-release.html

## Related Issue

GH-204


## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the [code style](CODE_STYLE.md) of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.




