### PR TITLE
GH-207 `aio-lib-java-events-mgmt`:   adding missing `x-conflicting-id` header safe guard within `ConflictException`

### DIFF
--- a/events_mgmt/pom.xml
+++ b/events_mgmt/pom.xml
@@ -33,6 +33,20 @@
       <artifactId>aio-lib-java-core</artifactId>
       <version>${project.version}</version>
     </dependency>
+    <dependency>
+      <groupId>com.adobe.aio</groupId>
+      <artifactId>aio-lib-java-ims</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+
+    <dependency>
+      <groupId>org.slf4j</groupId>
+      <artifactId>slf4j-simple</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>io.openapitools.jackson.dataformat</groupId>
+      <artifactId>jackson-dataformat-hal</artifactId>
+    </dependency>
 
     <!--  test -->
     <dependency>
@@ -40,18 +54,14 @@
        <artifactId>junit-jupiter</artifactId>
     </dependency>
     <dependency>
-      <groupId>org.slf4j</groupId>
-      <artifactId>slf4j-simple</artifactId>
+      <groupId>org.mockito</groupId>
+      <artifactId>mockito-core</artifactId>
     </dependency>
     <dependency>
-      <groupId>com.adobe.aio</groupId>
-      <artifactId>aio-lib-java-ims</artifactId>
-      <version>${project.version}</version>
+      <groupId>org.mockito</groupId>
+      <artifactId>mockito-junit-jupiter</artifactId>
     </dependency>
-    <dependency>
-      <groupId>io.openapitools.jackson.dataformat</groupId>
-      <artifactId>jackson-dataformat-hal</artifactId>
-    </dependency>
+
   </dependencies>
 
 </project>

--- a/events_mgmt/src/main/java/com/adobe/aio/event/management/feign/ConflictException.java
+++ b/events_mgmt/src/main/java/com/adobe/aio/event/management/feign/ConflictException.java
@@ -13,16 +13,17 @@ package com.adobe.aio.event.management.feign;
 
 import feign.FeignException;
 import feign.Response;
-import java.util.Optional;
+import java.util.Collection;
 
 public class ConflictException extends FeignException {
 
+  public static final String X_CONFLICTING_ID = "x-conflicting-id";
   private final String conflictingId;
 
   public ConflictException(Response response, FeignException exception) {
     super(response.status(), exception.getMessage(), response.request(), exception);
-    Optional<String> conflictingIdOptional = response.headers().get("x-conflicting-id").stream().findFirst();
-    conflictingId  = conflictingIdOptional.isPresent() ? conflictingIdOptional.get() : null;
+    Collection<String> conflictingIdHeader = response.headers().get(X_CONFLICTING_ID);
+    conflictingId  = conflictingIdHeader!=null ? conflictingIdHeader.stream().findFirst().orElse(null) : null;
   }
 
   public String getConflictingId() {

--- a/events_mgmt/src/test/java/com/adobe/aio/event/management/feign/ConflictExceptionTest.java
+++ b/events_mgmt/src/test/java/com/adobe/aio/event/management/feign/ConflictExceptionTest.java
@@ -1,0 +1,60 @@
+package com.adobe.aio.event.management.feign;
+
+import static com.adobe.aio.event.management.feign.ConflictException.X_CONFLICTING_ID;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.when;
+
+import feign.FeignException;
+import feign.Request;
+import feign.Response;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+public class ConflictExceptionTest {
+
+  @Mock
+  private Response response ;
+
+  @Mock
+  private Request request;
+
+  @Mock
+  private FeignException feignException;
+
+  @BeforeEach
+  void beforeeach() {
+    when(response.request()).thenReturn(request);
+  }
+
+  @Test
+  void withNoConflictIdHeader() {
+    when(response.headers()).thenReturn(Collections.emptyMap());
+    assertEquals(null, new ConflictException(response, feignException).getConflictingId());
+  }
+
+  @Test
+  void withEmptyConflictIdHeader() {
+    Map<String, Collection<String>> headers = new HashMap<>();
+    headers.put(X_CONFLICTING_ID, Collections.emptyList());
+    when(response.headers()).thenReturn(headers);
+    assertEquals(null, new ConflictException(response, feignException).getConflictingId());
+  }
+
+  @Test
+  void withConflictIdHeader() {
+    String conflictingId = "someId";
+    Map<String, Collection<String>> headers = new HashMap<>();
+    headers.put(X_CONFLICTING_ID, Collections.singletonList(conflictingId));
+    when(response.headers()).thenReturn(headers);
+    assertEquals(conflictingId, new ConflictException(response, feignException).getConflictingId());
+  }
+
+}


### PR DESCRIPTION

## Description

`aio-lib-java-events-mgmt`:   adding missing `x-conflicting-id` header safe guard within `ConflictException`

## Related Issue

#207 

## How Has This Been Tested?

added Unit test.

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:


- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the [code style](CODE_STYLE.md) of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.




