### PR TITLE
GH-213: enhance WorkspaceUtil to also search in envrionment variables

### DIFF
--- a/events_test/src/main/java/com/adobe/aio/event/management/RegistrationServiceTester.java
+++ b/events_test/src/main/java/com/adobe/aio/event/management/RegistrationServiceTester.java
@@ -15,7 +15,6 @@ import com.adobe.aio.event.management.model.EventsOfInterest;
 import com.adobe.aio.event.management.model.EventsOfInterestInputModel;
 import com.adobe.aio.event.management.model.Registration;
 import com.adobe.aio.event.management.model.RegistrationCreateModel;
-import com.adobe.aio.event.management.model.RegistrationUpdateModel;
 import com.adobe.aio.util.WorkspaceUtil;
 import com.adobe.aio.workspace.Workspace;
 import java.net.MalformedURLException;

--- a/events_test/src/test/java/com/adobe/aio/event/management/ProviderServiceIntegrationTest.java
+++ b/events_test/src/test/java/com/adobe/aio/event/management/ProviderServiceIntegrationTest.java
@@ -11,12 +11,10 @@
  */
 package com.adobe.aio.event.management;
 
-import com.adobe.aio.event.management.model.ProviderInputModel;
 import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
 
-import com.adobe.aio.event.management.feign.ConflictException;
 import com.adobe.aio.event.management.model.EventMetadata;
 import com.adobe.aio.event.management.model.Provider;
 import com.adobe.aio.util.WorkspaceUtil;

--- a/ims/src/main/java/com/adobe/aio/util/WorkspaceUtil.java
+++ b/ims/src/main/java/com/adobe/aio/util/WorkspaceUtil.java
@@ -47,6 +47,23 @@ public class WorkspaceUtil {
       return Workspace.builder()
           .properties(System.getProperties())
           .privateKey(privateKey);
+    } else if (StringUtils.isNoneBlank(
+        System.getenv(PrivateKeyBuilder.AIO_ENCODED_PKCS_8),
+        System.getenv(Workspace.API_KEY),
+        System.getenv(Workspace.WORKSPACE_ID),
+        System.getenv(Workspace.CLIENT_SECRET),
+        System.getenv(Workspace.CONSUMER_ORG_ID),
+        System.getenv(Workspace.CREDENTIAL_ID),
+        System.getenv(Workspace.IMS_ORG_ID),
+        System.getenv(Workspace.META_SCOPES),
+        System.getenv(Workspace.PROJECT_ID),
+        System.getenv(Workspace.TECHNICAL_ACCOUNT_ID))) {
+      logger.debug("loading test Workspace from JVM System Properties");
+      PrivateKey privateKey =
+          new PrivateKeyBuilder()
+              .encodedPkcs8Key(System.getenv(PrivateKeyBuilder.AIO_ENCODED_PKCS_8))
+              .build();
+      return Workspace.builder().systemEnv().privateKey(privateKey);
     } else {
       /**
        * WARNING: don't push back your workspace secrets to github

--- a/ims/src/main/java/com/adobe/aio/util/WorkspaceUtil.java
+++ b/ims/src/main/java/com/adobe/aio/util/WorkspaceUtil.java
@@ -29,6 +29,17 @@ public class WorkspaceUtil {
   private WorkspaceUtil() {
   }
 
+  /**
+   * Loads configurations for a Workspace from either one and only one of the following
+   * sources, probing them first to check that all the required properties are given,
+   * in order:
+   * <ol>
+   *   <li>System Properties</li>
+   *   <li>Environment Variables</li>
+   *   <li>classpath:{@link WorkspaceUtil#DEFAULT_TEST_PROPERTIES}</li>
+   * </ol>
+   * @return a Workspace.Builder loaded with the provided config
+   */
   public static Workspace.Builder getSystemWorkspaceBuilder() {
     if (StringUtils.isNoneBlank(
         System.getProperty(PrivateKeyBuilder.AIO_ENCODED_PKCS_8),

--- a/ims/src/main/java/com/adobe/aio/util/WorkspaceUtil.java
+++ b/ims/src/main/java/com/adobe/aio/util/WorkspaceUtil.java
@@ -88,15 +88,30 @@ public class WorkspaceUtil {
     return getSystemProperty(key,DEFAULT_TEST_PROPERTIES);
   }
 
+  /**
+   * Loads a property from either one of the following sources, probing it first to
+   * check that the required property is given, in order:
+   * <ol>
+   *   <li>System Properties</li>
+   *   <li>Environment Variables</li>
+   *   <li>classpath:{@code propertyClassPath}</li>
+   * </ol>
+   *
+   * @param key the property name
+   * @param propertyClassPath the classpath of the property file
+   * @return the value of the property
+   */
   public static String getSystemProperty(String key, String propertyClassPath) {
-    String value = System.getProperty(key);
-    if (StringUtils.isBlank(value)) {
-      logger.debug("loading property `{}` from classpath `{}`", key, propertyClassPath);
-      value = FileUtil.readPropertiesFromClassPath(propertyClassPath).getProperty(key);
-    } else {
+    if (StringUtils.isNotBlank(System.getProperty(key))) {
       logger.debug("loading property `{}`from JVM System Properties", key);
+      return System.getProperty(key);
+    } if (StringUtils.isNotBlank(System.getenv(key))) {
+      logger.debug("loading property `{}` from Environment Variables", key);
+      return System.getenv(key);
+    } else {
+      logger.debug("loading property `{}` from classpath `{}`", key, propertyClassPath);
+      return FileUtil.readPropertiesFromClassPath(propertyClassPath).getProperty(key);
     }
-    return value;
   }
 
   private static Workspace.Builder getWorkspaceBuilder(String propertyFileClassPath) {


### PR DESCRIPTION
See: #213 

## Description

As described in the issue, added the possibility to get the configuration for the `Workspace` from environment variables, which makes it easier to use.

Breaking change: renamed the method `WorkspaceUtil#getSystemWorkspaceBuilder` to `WorkspaceUtil#getWorkspaceBuilder`.

## Related Issue
 
#213 

## Motivation and Context

Enable the usage of environment variables in docker containers where an entrypoint is defined in exec form, passing the configurations through ENV variables without the need to bind them using the system properties, which turns out to be really cumbersome.

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [ ] My code follows the [code style](CODE_STYLE.md) of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.




