### PR TITLE
GH-213: enhance WorkspaceUtil to also search in environment variables…

### DIFF
--- a/events_test/src/main/java/com/adobe/aio/event/management/RegistrationServiceTester.java
+++ b/events_test/src/main/java/com/adobe/aio/event/management/RegistrationServiceTester.java
@@ -15,7 +15,6 @@ import com.adobe.aio.event.management.model.EventsOfInterest;
 import com.adobe.aio.event.management.model.EventsOfInterestInputModel;
 import com.adobe.aio.event.management.model.Registration;
 import com.adobe.aio.event.management.model.RegistrationCreateModel;
-import com.adobe.aio.event.management.model.RegistrationUpdateModel;
 import com.adobe.aio.util.WorkspaceUtil;
 import com.adobe.aio.workspace.Workspace;
 import java.net.MalformedURLException;

--- a/events_test/src/test/java/com/adobe/aio/event/management/ProviderServiceIntegrationTest.java
+++ b/events_test/src/test/java/com/adobe/aio/event/management/ProviderServiceIntegrationTest.java
@@ -11,12 +11,10 @@
  */
 package com.adobe.aio.event.management;
 
-import com.adobe.aio.event.management.model.ProviderInputModel;
 import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
 
-import com.adobe.aio.event.management.feign.ConflictException;
 import com.adobe.aio.event.management.model.EventMetadata;
 import com.adobe.aio.event.management.model.Provider;
 import com.adobe.aio.util.WorkspaceUtil;


### PR DESCRIPTION
See: #213 

## Description

As described in the issue, added the possibility to get the configuration for the `Workspace` from environment variables, which makes it easier to use.

## Related Issue
 
#213 
https://github.com/adobe/aio-lib-java/pull/214

## Motivation and Context

Enable the usage of environment variables in docker containers where an entrypoint is defined in exec form, passing the configurations through ENV variables without the need to bind them using the system properties, which turns out to be really cumbersome.

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [ ] My code follows the [code style](CODE_STYLE.md) of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.




