### PR TITLE
GH-230 removing unwanted/unneeded/unused cloudevent serializer and deserializer and hence dependency

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -71,10 +71,6 @@
       <groupId>io.openapitools.jackson.dataformat</groupId>
       <artifactId>jackson-dataformat-hal</artifactId>
     </dependency>
-    <dependency>
-      <groupId>io.cloudevents</groupId>
-      <artifactId>cloudevents-api</artifactId>
-    </dependency>
 
     <dependency>
        <groupId>org.junit.jupiter</groupId>

--- a/core/src/main/java/com/adobe/aio/util/JacksonUtil.java
+++ b/core/src/main/java/com/adobe/aio/util/JacksonUtil.java
@@ -20,8 +20,6 @@ import com.fasterxml.jackson.databind.json.JsonMapper;
 import com.fasterxml.jackson.databind.module.SimpleModule;
 import com.fasterxml.jackson.databind.node.TextNode;
 import com.fasterxml.jackson.datatype.jdk8.Jdk8Module;
-import io.cloudevents.json.ZonedDateTimeDeserializer;
-import io.cloudevents.json.ZonedDateTimeSerializer;
 import io.openapitools.jackson.dataformat.hal.JacksonHALModule;
 import java.time.ZonedDateTime;
 import org.apache.commons.lang3.StringUtils;
@@ -35,10 +33,6 @@ public class JacksonUtil {
       JsonMapper.builder()
           .configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false)
           .serializationInclusion(Include.NON_NULL)
-          .addModule(new SimpleModule()
-              .addSerializer(ZonedDateTime.class, new ZonedDateTimeSerializer())
-              .addDeserializer(ZonedDateTime.class, new ZonedDateTimeDeserializer()))
-           // let's stick to CloudEvents v1 ISO_OFFSET_DATE_TIME date format
           .addModule(new JacksonHALModule())
           .addModule(new Jdk8Module())
           .build();

--- a/core/src/main/java/com/adobe/aio/util/JacksonUtil.java
+++ b/core/src/main/java/com/adobe/aio/util/JacksonUtil.java
@@ -17,11 +17,9 @@ import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.json.JsonMapper;
-import com.fasterxml.jackson.databind.module.SimpleModule;
 import com.fasterxml.jackson.databind.node.TextNode;
 import com.fasterxml.jackson.datatype.jdk8.Jdk8Module;
 import io.openapitools.jackson.dataformat.hal.JacksonHALModule;
-import java.time.ZonedDateTime;
 import org.apache.commons.lang3.StringUtils;
 
 public class JacksonUtil {

--- a/pom.xml
+++ b/pom.xml
@@ -104,9 +104,6 @@
     <jackson.version>2.13.4</jackson.version>
     <jjwt.version>0.11.5</jjwt.version>
 
-    <cloudevents.version>1.2.0</cloudevents.version>
-    <!--  we'll stick to this CloudEvents v1 version for now -->
-
     <!-- https://github.com/openapi-tools/jackson-dataformat-hal/blob/v1.0.9/pom.xml -->
     <jackson-dataformat-hal.version>1.0.9</jackson-dataformat-hal.version>
 
@@ -122,12 +119,6 @@
         <groupId>org.apache.commons</groupId>
         <artifactId>commons-text</artifactId>
         <version>${commons-text.version}</version>
-      </dependency>
-
-      <dependency>
-        <groupId>io.cloudevents</groupId>
-        <artifactId>cloudevents-api</artifactId>
-        <version>${cloudevents.version}</version>
       </dependency>
 
       <dependency>


### PR DESCRIPTION
## Related Issue

GH-230

## Motivation and Context

* removing unwanted/unneeded/unused cloudevent serializer and deserializer and hence dependency 
* It was introduced here https://github.com/adobe/aio-lib-java/pull/126 
  * not sure why
  * reminder: ISO Date formatting is coming for free in Jackson when using `@JsonFormat`
  
* we still have this https://github.com/adobe/aio-lib-java/issues/16 pending
* but for now I propose we remove this annoying dependency


## Types of changes


- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the [code style](CODE_STYLE.md) of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.




