### PR TITLE
GH-236 aligning the GH action to the use of `central-publishing-maven-plugin` plugin

### DIFF
--- a/.github/workflows/maven-release.yml
+++ b/.github/workflows/maven-release.yml
@@ -194,7 +194,6 @@ jobs:
           distribution: 'temurin'
           java-version: 11
           cache: maven
-          server-id: ossrh
           server-username: MAVEN_USERNAME
           server-password: MAVEN_CENTRAL_TOKEN
           gpg-private-key: ${{ secrets.MAVEN_GPG_PRIVATE_KEY }}
@@ -209,21 +208,21 @@ jobs:
           echo $GPG_OWNERTRUST | base64 --decode | gpg --import-ownertrust --no-tty --batch --yes
 
       - name: AEM6.5 Build
-        run: mvn clean deploy -DskipRemoteStaging=true -Dmaven.test.skip -Paem65deps,aem65,release
+        run: mvn clean deploy -DskipTests -Paem65deps,aem65,release
         env:
           MAVEN_USERNAME: ${{ secrets.SONATYPE_USERNAME }}
           MAVEN_CENTRAL_TOKEN: ${{ secrets.SONATYPE_PASSWORD }}
           MAVEN_GPG_PASSPHRASE: ${{ secrets.GPG_PASSPHRASE }}
 
       - name: AEMaaCS Build
-        run: mvn clean deploy -DskipRemoteStaging=true -PaemaacsDeps,aemaacs,release,attach-javadoc,attach-source
+        run: mvn clean deploy -DskipTests -PaemaacsDeps,aemaacs,release,attach-javadoc,attach-source
         env:
           MAVEN_USERNAME: ${{ secrets.SONATYPE_USERNAME }}
           MAVEN_CENTRAL_TOKEN: ${{ secrets.SONATYPE_PASSWORD }}
           MAVEN_GPG_PASSPHRASE: ${{ secrets.GPG_PASSPHRASE }}
 
-      - name: Deploy to Central
-        run: mvn nexus-staging:deploy-staged -DautoReleaseAfterClose=true
+      - name: Main Build
+        run: mvn clean deploy -DskipTests
         env:
           MAVEN_USERNAME: ${{ secrets.SONATYPE_USERNAME }}
           MAVEN_CENTRAL_TOKEN: ${{ secrets.SONATYPE_PASSWORD }}

--- a/.github/workflows/maven-snapshot.yml
+++ b/.github/workflows/maven-snapshot.yml
@@ -28,28 +28,27 @@ jobs:
           distribution: 'temurin'
           java-version: 11
           cache: maven
-          server-id: ossrh
           server-username: MAVEN_USERNAME
           server-password: MAVEN_CENTRAL_TOKEN
           gpg-private-key: ${{ secrets.MAVEN_GPG_PRIVATE_KEY }}
           gpg-passphrase: MAVEN_GPG_PASSPHRASE
 
       - name: AEM6.5 Build
-        run: mvn clean deploy -DskipRemoteStaging=true -Dmaven.test.skip -Paem65deps,aem65,release
+        run: mvn clean deploy -DskipTests -Paem65deps,aem65,release
         env:
           MAVEN_USERNAME: ${{ secrets.SONATYPE_USERNAME }}
           MAVEN_CENTRAL_TOKEN: ${{ secrets.SONATYPE_PASSWORD }}
           MAVEN_GPG_PASSPHRASE: ${{ secrets.GPG_PASSPHRASE }}
 
       - name: AEMaaCS Build
-        run: mvn clean deploy -DskipRemoteStaging=true -PaemaacsDeps,aemaacs,release,attach-javadoc,attach-source
+        run: mvn clean deploy -PaemaacsDeps,aemaacs,release,attach-javadoc,attach-source
         env:
           MAVEN_USERNAME: ${{ secrets.SONATYPE_USERNAME }}
           MAVEN_CENTRAL_TOKEN: ${{ secrets.SONATYPE_PASSWORD }}
           MAVEN_GPG_PASSPHRASE: ${{ secrets.GPG_PASSPHRASE }}
           
-      - name: Deploy to Central
-        run: mvn nexus-staging:deploy-staged -DautoReleaseAfterClose=true
+      - name: Main Build
+        run: mvn clean deploy -DskipTests
         env:
           MAVEN_USERNAME: ${{ secrets.SONATYPE_USERNAME }}
           MAVEN_CENTRAL_TOKEN: ${{ secrets.SONATYPE_PASSWORD }}

--- a/pom.xml
+++ b/pom.xml
@@ -76,17 +76,6 @@
     <tag>HEAD</tag>
   </scm>
 
-  <distributionManagement>
-    <snapshotRepository>
-      <id>ossrh</id>
-      <url>https://oss.sonatype.org/content/repositories/snapshots</url>
-    </snapshotRepository>
-    <repository>
-      <id>ossrh</id>
-      <url>https://oss.sonatype.org/service/local/staging/deploy/maven2/</url>
-    </repository>
-  </distributionManagement>
-
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
@@ -273,14 +262,12 @@
         <artifactId>jacoco-maven-plugin</artifactId>
       </plugin>
       <plugin>
-        <groupId>org.sonatype.plugins</groupId>
-        <artifactId>nexus-staging-maven-plugin</artifactId>
+        <groupId>org.sonatype.central</groupId>
+        <artifactId>central-publishing-maven-plugin</artifactId>
+        <version>0.8.0</version>
         <extensions>true</extensions>
         <configuration>
-          <stagingProgressTimeoutMinutes>30</stagingProgressTimeoutMinutes>
-          <altStagingDirectory>${maven.multiModuleProjectDirectory}/dist/nexus-staging</altStagingDirectory>
-          <serverId>ossrh</serverId>
-          <nexusUrl>https://oss.sonatype.org/</nexusUrl>
+          <publishingServerId>central</publishingServerId>
         </configuration>
       </plugin>
     </plugins>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

GH-236 

As of June 30, 2025 Sonatype OSSRH has reached end of life and has been shut down. All OSSRH namespaces have been migrated to Central Publisher Portal.

Hence migrating to `central.sonatype.com` see https://github.com/adobe/aio-lib-java/pull/237
and now with this aligning the GH actions with the above change


## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the [code style](CODE_STYLE.md) of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.


